### PR TITLE
Improve parser update logic

### DIFF
--- a/database.py
+++ b/database.py
@@ -156,6 +156,35 @@ def update_participant(participant_id: int, participant_data: Dict) -> bool:
             conn.close()
 
 
+def update_participant_field(participant_id: int, field: str, value: str) -> bool:
+    """Обновляет одно поле участника"""
+    allowed_fields = [
+        'FullNameRU', 'Gender', 'Size', 'CountryAndCity', 'Church',
+        'Role', 'Department', 'FullNameEN', 'SubmittedBy', 'ContactInformation'
+    ]
+
+    if field not in allowed_fields:
+        return False
+
+    conn = None
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute(
+            f"UPDATE participants SET {field} = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (value, participant_id),
+        )
+        updated = cursor.rowcount > 0
+        conn.commit()
+        return updated
+    except sqlite3.Error as e:
+        logger.error("Failed to update participant field: %s", e)
+        return False
+    finally:
+        if conn:
+            conn.close()
+
+
 def find_participant_by_name(full_name_ru: str) -> Optional[Dict]:
     conn = None
     try:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,5 +24,15 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(data['CountryAndCity'], 'Афула')
         self.assertEqual(data['Church'], 'церковь Благодать')
 
+    def test_update_gender_only(self):
+        text = "Пол женский"
+        data = parse_participant_data(text, is_update=True)
+        self.assertEqual(data, {'Gender': 'F'})
+
+    def test_size_medium_synonym(self):
+        text = "размер medium"
+        data = parse_participant_data(text, is_update=True)
+        self.assertEqual(data, {'Size': 'M'})
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support field correction parsing with updated `parse_participant_data`
- handle correction mode during participant confirmation
- allow single-field DB updates
- extend parser capabilities and constants
- add tests for gender update and size synonyms

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d293f307c8324bb0940354559c292