### PR TITLE
Update size vocabulary and validation

### DIFF
--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -28,7 +28,15 @@ DEPARTMENT_KEYWORDS = {
 }
 
 CHURCH_KEYWORDS = ['ЦЕРКОВЬ', 'CHURCH', 'ХРАМ', 'ОБЩИНА']
-SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', '2XL', '3XL', 'М', 'Л', 'С', 'MEDIUM', 'LARGE', 'SMALL']
+SIZES = [
+    'XS', 'EXTRA SMALL', 'EXTRASMALL',
+    'S', 'SMALL',
+    'M', 'MEDIUM',
+    'L', 'LARGE',
+    'XL', 'EXTRA LARGE', 'EXTRALARGE',
+    'XXL', '2XL', 'EXTRA EXTRA LARGE',
+    '3XL', 'XXXL'
+]
 
 ISRAEL_CITIES = [
     'ХАЙФА', 'HAIFA', 'ТЕЛ-АВИВ', 'TEL AVIV', 'ТЕЛЬ-АВИВ', 'ИЕРУСАЛИМ', 'JERUSALEM',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,7 +20,7 @@ class ParserTestCase(unittest.TestCase):
         text = "Ольга Сергеевна жен М Афула церковь Благодать"
         data = parse_participant_data(text)
         self.assertEqual(data['Gender'], 'F')
-        self.assertEqual(data['Size'], 'М')
+        self.assertEqual(data['Size'], '')
         self.assertEqual(data['CountryAndCity'], 'Афула')
         self.assertEqual(data['Church'], 'церковь Благодать')
 

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -1,9 +1,17 @@
 from typing import Dict
 
-VALID_SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', '2XL', '3XL']
+VALID_SIZES = [
+    'XS', 'EXTRA SMALL', 'EXTRASMALL',
+    'S', 'SMALL',
+    'M', 'MEDIUM',
+    'L', 'LARGE',
+    'XL', 'EXTRA LARGE', 'EXTRALARGE',
+    'XXL', '2XL', 'EXTRA EXTRA LARGE',
+    '3XL', 'XXXL'
+]
 
 def validate_size(size: str) -> bool:
-    return size.upper() in VALID_SIZES
+    return size.upper() in [s.upper() for s in VALID_SIZES]
 
 
 def validate_participant_data(data: Dict) -> (bool, str):


### PR DESCRIPTION
## Summary
- standardize allowed size values to English variants only
- support case-insensitive size validation
- adjust tests for updated size handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3278d054832484704aa298691117