### PR TITLE
Improve confirmation template parsing

### DIFF
--- a/tests/test_confirmation_template.py
+++ b/tests/test_confirmation_template.py
@@ -1,0 +1,34 @@
+import unittest
+from main import parse_confirmation_template
+
+class ConfirmationTemplateTestCase(unittest.TestCase):
+    def test_basic_parse(self):
+        text = "\n".join([
+            "👤 **Имя (рус):** Ирина Цой",
+            "⚥ **Пол:** F",
+            "👕 **Размер:** M",
+        ])
+        data = parse_confirmation_template(text)
+        self.assertEqual(data, {
+            'FullNameRU': 'Ирина Цой',
+            'Gender': 'F',
+            'Size': 'M'
+        })
+
+    def test_ignore_service_values(self):
+        text = "\n".join([
+            "👤 **Имя (рус):** Ирина Цой",
+            "⚥ **Пол:** F",
+            "👕 **Размер:** ❌ Не указано",
+            "🏢 **Департамент:** ➖ Не указано",
+        ])
+        data = parse_confirmation_template(text)
+        self.assertEqual(data, {
+            'FullNameRU': 'Ирина Цой',
+            'Gender': 'F',
+            'Size': '',
+            'Department': ''
+        })
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance `parse_confirmation_template` to properly strip emojis, split lines and filter service values
- add unit tests for parsing confirmation templates

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d33bdee94832494624e96086ee346