### PR TITLE
Fix confirmation template parser

### DIFF
--- a/tests/test_confirmation_template.py
+++ b/tests/test_confirmation_template.py
@@ -30,5 +30,16 @@ class ConfirmationTemplateTestCase(unittest.TestCase):
             'Department': ''
         })
 
+    def test_church_parsing(self):
+        text = "\n".join([
+            "👤 **Имя (рус):** Ирина Цой",
+            "⛪ **Церковь:** церковь Грейс",
+        ])
+        data = parse_confirmation_template(text)
+        self.assertEqual(data, {
+            'FullNameRU': 'Ирина Цой',
+            'Church': 'церковь Грейс'
+        })
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- rewrite `parse_confirmation_template` for robust extraction
- cover church parsing case in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d36c0492c8324bb90c581aa8ee454