### PR TITLE
Refactor constants into dedicated module

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,60 @@
+from enum import Enum
+
+class Gender(Enum):
+    MALE = 'M'
+    FEMALE = 'F'
+
+class Role(Enum):
+    CANDIDATE = 'CANDIDATE'
+    TEAM = 'TEAM'
+
+GENDER_KEYWORDS = {
+    Gender.MALE.value: ['M', 'МУЖ', 'МУЖСКОЙ', 'MALE', 'М', 'МУЖЧИНА'],
+    Gender.FEMALE.value: ['F', 'ЖЕН', 'ЖЕНСКИЙ', 'FEMALE', 'Ж', 'ЖЕНЩИНА']
+}
+
+ROLE_KEYWORDS = {
+    Role.TEAM.value: ['TEAM', 'КОМАНДА', 'ТИМ', 'TIM', 'TEAM MEMBER', 'ЧЛЕН КОМАНДЫ', 'КОМАНДНЫЙ', 'СЛУЖИТЕЛЬ'],
+    Role.CANDIDATE.value: ['CANDIDATE', 'КАНДИДАТ', 'УЧАСТНИК', 'КАНДИДАТКА']
+}
+
+DEPARTMENT_KEYWORDS = {
+    'ROE': [
+        'ROE', 'РОЕ', 'ROE ROOM', 'РОЕ РУМ', 'РОЭ', 'РОИ',
+        'roe', 'рое', 'roe room', 'рое рум', 'роэ'
+    ],
+    'Chapel': ['CHAPEL', 'МОЛИТВЕННЫЙ', 'МОЛИТВА', 'PRAYER', 'ЧАСОВНЯ'],
+    'Setup': ['SETUP', 'СЕТАП', 'НАСТРОЙКА', 'ПОДГОТОВКА', 'СЕТ АП'],
+    'Palanka': ['PALANKA', 'ПАЛАНКА', 'ПОЛАНКА'],
+    'Administration': ['ADMINISTRATION', 'АДМИНИСТРАЦИЯ', 'АДМИН', 'ADMIN', 'УПРАВЛЕНИЕ'],
+    'Kitchen': ['KITCHEN', 'КУХНЯ', 'КИТЧЕН', 'КУЛИНАРИЯ', 'ПОВАРА'],
+    'Decoration': ['DECORATION', 'ДЕКОРАЦИИ', 'ДЕКОР', 'DECO', 'DECOR', 'УКРАШЕНИЕ', 'ОФОРМЛЕНИЕ'],
+    'Bell': ['BELL', 'ЗВОНАРЬ', 'БЕЛЛ', 'ЗВОН', 'КОЛОКОЛЬЧИК'],
+    'Refreshment': ['REFRESHMENT', 'РЕФРЕШМЕНТ', 'УГОЩЕНИЯ', 'НАПИТКИ'],
+    'Worship': ['WORSHIP', 'ПРОСЛАВЛЕНИЕ', 'ВОРШИП', 'МУЗЫКА', 'MUSIC'],
+    'Media': ['MEDIA', 'МЕДИА', 'ВИДЕО', 'ФОТО', 'СЪЕМКА', 'КАМЕРА', 'ФОТОГРАФ'],
+    'Духовенство': ['ДУХОВЕНСТВО', 'CLERGY', 'СВЯЩЕННИКИ'],
+    'Ректорат': ['РЕКТОРАТ', 'RECTOR', 'РЕКТОРЫ']
+}
+
+SIZES = [
+    'XS', 'EXTRA SMALL', 'EXTRASMALL',
+    'S', 'SMALL',
+    'M', 'MEDIUM',
+    'L', 'LARGE',
+    'XL', 'EXTRA LARGE', 'EXTRALARGE',
+    'XXL', '2XL', 'EXTRA EXTRA LARGE',
+    '3XL', 'XXXL'
+]
+
+ISRAEL_CITIES = [
+    'ХАЙФА', 'HAIFA', 'ТЕЛ-АВИВ', 'TEL AVIV', 'ТЕЛЬ-АВИВ', 'ИЕРУСАЛИМ', 'JERUSALEM',
+    'БЕЭР-ШЕВА', 'BEER SHEVA', 'НЕТАНИЯ', 'NETANYA', 'АШДОД', 'ASHDOD',
+    'РИШОН-ЛЕ-ЦИОН', 'РИШОН ЛЕ ЦИОН', 'РИШОН-ЛЕ ЦИОН', 'РИШОН ЛЕЦИОН',
+    'RISHON LEZION', 'RISHON-LEZION', 'RISHON LE ZION', 'RISHON-LE ZION',
+    'ПЕТАХ-ТИКВА', 'PETAH TIKVA', 'РЕХОВОТ', 'REHOVOT',
+    'БАТ-ЯМ', 'BAT YAM', 'КАРМИЭЛЬ', 'CARMIEL', 'МОДИИН', 'MODIIN', 'НАЗАРЕТ', 'NAZARETH',
+    'КИРЬЯТ-ГАТ', 'KIRYAT GAT', 'ЭЙЛАТ', 'EILAT', 'АККО', 'ACRE', 'РАМАТ-ГАН', 'RAMAT GAN',
+    'БНЕЙ-БРАК', 'BNEI BRAK', 'ЦФАТ', 'SAFED', 'ТВЕРИЯ', 'TIBERIAS', 'ГЕРЦЛИЯ', 'HERZLIYA',
+    'АФУЛА', 'AFULA'
+]

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -2,59 +2,19 @@ from typing import Dict, Optional
 import re
 import logging
 
+from constants import (
+    GENDER_KEYWORDS,
+    ROLE_KEYWORDS,
+    DEPARTMENT_KEYWORDS,
+    SIZES,
+    ISRAEL_CITIES,
+    Gender,
+    Role,
+)
+
 logger = logging.getLogger(__name__)
 
-GENDER_KEYWORDS = {
-    'M': ['M', 'МУЖ', 'МУЖСКОЙ', 'MALE', 'М', 'МУЖЧИНА'],
-    'F': ['F', 'ЖЕН', 'ЖЕНСКИЙ', 'FEMALE', 'Ж', 'ЖЕНЩИНА']
-}
-
-ROLE_KEYWORDS = {
-    'TEAM': ['TEAM', 'КОМАНДА', 'ТИМ', 'TIM', 'TEAM MEMBER', 'ЧЛЕН КОМАНДЫ', 'КОМАНДНЫЙ', 'СЛУЖИТЕЛЬ'],
-    'CANDIDATE': ['CANDIDATE', 'КАНДИДАТ', 'УЧАСТНИК', 'КАНДИДАТКА']
-}
-
-DEPARTMENT_KEYWORDS = {
-    'ROE': [
-        'ROE', 'РОЕ', 'ROE ROOM', 'РОЕ РУМ', 'РОЭ', 'РОИ',
-        'roe', 'рое', 'roe room', 'рое рум', 'роэ'
-    ],
-    'Chapel': ['CHAPEL', 'МОЛИТВЕННЫЙ', 'МОЛИТВА', 'PRAYER', 'ЧАСОВНЯ'],
-    'Setup': ['SETUP', 'СЕТАП', 'НАСТРОЙКА', 'ПОДГОТОВКА', 'СЕТ АП'],
-    'Palanka': ['PALANKA', 'ПАЛАНКА', 'ПОЛАНКА'],
-    'Administration': ['ADMINISTRATION', 'АДМИНИСТРАЦИЯ', 'АДМИН', 'ADMIN', 'УПРАВЛЕНИЕ'],
-    'Kitchen': ['KITCHEN', 'КУХНЯ', 'КИТЧЕН', 'КУЛИНАРИЯ', 'ПОВАРА'],
-    'Decoration': ['DECORATION', 'ДЕКОРАЦИИ', 'ДЕКОР', 'DECO', 'DECOR', 'УКРАШЕНИЯ', 'ОФОРМЛЕНИЕ'],
-    'Bell': ['BELL', 'ЗВОНАРЬ', 'БЕЛЛ', 'ЗВОН', 'КОЛОКОЛЬЧИК'],
-    'Refreshment': ['REFRESHMENT', 'РЕФРЕШМЕНТ', 'УГОЩЕНИЯ', 'НАПИТКИ'],
-    'Worship': ['WORSHIP', 'ПРОСЛАВЛЕНИЕ', 'ВОРШИП', 'МУЗЫКА', 'MUSIC'],
-    'Media': ['MEDIA', 'МЕДИА', 'ВИДЕО', 'ФОТО', 'СЪЕМКА', 'КАМЕРА', 'ФОТОГРАФ'],
-    'Духовенство': ['ДУХОВЕНСТВО', 'CLERGY', 'СВЯЩЕННИКИ'],
-    'Ректорат': ['РЕКТОРАТ', 'RECTOR', 'РЕКТОРЫ']
-}
-
 CHURCH_KEYWORDS = ['ЦЕРКОВЬ', 'CHURCH', 'ХРАМ', 'ОБЩИНА']
-SIZES = [
-    'XS', 'EXTRA SMALL', 'EXTRASMALL',
-    'S', 'SMALL',
-    'M', 'MEDIUM',
-    'L', 'LARGE',
-    'XL', 'EXTRA LARGE', 'EXTRALARGE',
-    'XXL', '2XL', 'EXTRA EXTRA LARGE',
-    '3XL', 'XXXL'
-]
-
-ISRAEL_CITIES = [
-    'ХАЙФА', 'HAIFA', 'ТЕЛ-АВИВ', 'TEL AVIV', 'ТЕЛЬ-АВИВ', 'ИЕРУСАЛИМ', 'JERUSALEM',
-    'БЕЭР-ШЕВА', 'BEER SHEVA', 'НЕТАНИЯ', 'NETANYA', 'АШДОД', 'ASHDOD',
-    'РИШОН-ЛЕ-ЦИОН', 'РИШОН ЛЕ ЦИОН', 'РИШОН-ЛЕ ЦИОН', 'РИШОН ЛЕЦИОН',
-    'RISHON LEZION', 'RISHON-LEZION', 'RISHON LE ZION', 'RISHON-LE ZION',
-    'ПЕТАХ-ТИКВА', 'PETAH TIKVA', 'РЕХОВОТ', 'REHOVOT',
-    'БАТ-ЯМ', 'BAT YAM', 'КАРМИЭЛЬ', 'CARMIEL', 'МОДИИН', 'MODIIN', 'НАЗАРЕТ', 'NAZARETH',
-    'КИРЬЯТ-ГАТ', 'KIRYAT GAT', 'ЭЙЛАТ', 'EILAT', 'АККО', 'ACRE', 'РАМАТ-ГАН', 'RAMAT GAN',
-    'БНЕЙ-БРАК', 'BNEI BRAK', 'ЦФАТ', 'SAFED', 'ТВЕРИЯ', 'TIBERIAS', 'ГЕРЦЛИЯ', 'HERZLIYA',
-    'АФУЛА', 'AFULA'
-]
 
 # Служебные слова, которые встречаются в блоке подтверждения
 CONFIRMATION_NOISE_WORDS = {


### PR DESCRIPTION
## Summary
- centralize participant parser constants in new `constants.py`
- update `participant_parser` to import from `constants`

## Testing
- `PYTHONPATH=. python tests/test_parser.py`
- `PYTHONPATH=. python tests/test_confirmation_template.py`


------
https://chatgpt.com/codex/tasks/task_e_687de09edabc8324a8df3d5b215da087