### PR TITLE
Add logging with rotation and SQL tracing

### DIFF
--- a/database.py
+++ b/database.py
@@ -22,6 +22,8 @@ class DatabaseConnection:
     def __enter__(self) -> sqlite3.Connection:
         self.conn = sqlite3.connect(DB_PATH)
         self.conn.row_factory = sqlite3.Row
+        sql_logger = logging.getLogger('sql')
+        self.conn.set_trace_callback(sql_logger.info)
         return self.conn
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:


### PR DESCRIPTION
## Summary
- configure rotating log files
- track user actions for each command and message
- record parser errors with input text
- log all SQL queries via connection trace callback

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ded8a4a988324ab0d190cac791bdd