### PR TITLE
Fix check for nonexistent participants

### DIFF
--- a/database.py
+++ b/database.py
@@ -262,6 +262,7 @@ def update_participant_field(participant_id: int, field_updates: Dict) -> bool:
 
 
 def find_participant_by_name(full_name_ru: str) -> Optional[Dict]:
+    """Ищет участника по имени. Возвращает dict или None, если не найден."""
     try:
         with DatabaseConnection() as conn:
             cursor = conn.cursor()
@@ -270,13 +271,13 @@ def find_participant_by_name(full_name_ru: str) -> Optional[Dict]:
                 (full_name_ru,),
             )
             row = cursor.fetchone()
+            # Если строка не найдена, просто возвращаем None. Это не ошибка.
             if not row:
-                raise ParticipantNotFoundError(
-                    f"Participant with name '{full_name_ru}' not found"
-                )
+                return None
             return dict(row)
     except sqlite3.Error as e:
         logger.error("Database error while searching participant: %s", e)
+        # В случае реальной ошибки БД, мы по-прежнему генерируем исключение.
         raise BotException("Database error while searching participant") from e
 
 

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -79,7 +79,12 @@ def detect_changes(old: Dict, new: Dict) -> List[str]:
 
 
 def check_duplicate(full_name_ru: str) -> Optional[Dict]:
-    return find_participant_by_name(full_name_ru)
+    """Проверяет наличие дубликата по имени. Возвращает dict или None."""
+    try:
+        return find_participant_by_name(full_name_ru)
+    except ParticipantNotFoundError:
+        # На случай, если поиск по имени сгенерирует исключение
+        return None
 
 
 class ParticipantService:


### PR DESCRIPTION
## Summary
- prevent exceptions when searching for non-existent participants
- handle potential ParticipantNotFoundError in duplicate check

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687defecff5883249c654b26afaeff2b