### PR TITLE
Normalize participant fields

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -106,5 +106,28 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(data['Size'], 'L')
         self.assertEqual(data['Church'], 'Благодать')
 
+    def test_template_normalization(self):
+        text = "\n".join([
+            "Имя (рус): Иван Петров",
+            "Пол: муж",
+            "Размер: extra large",
+            "Роль: тим",
+            "Департамент: админ",
+        ])
+        data = parse_participant_data(text)
+        self.assertEqual(data['Gender'], 'M')
+        self.assertEqual(data['Size'], 'XL')
+        self.assertEqual(data['Role'], 'TEAM')
+        self.assertEqual(data['Department'], 'Administration')
+
+    def test_template_unknown_department(self):
+        text = "\n".join([
+            "Имя (рус): Иван",
+            "Пол: M",
+            "Департамент: Support",
+        ])
+        data = parse_participant_data(text)
+        self.assertEqual(data['Department'], '')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize gender, role, department and size values during parsing
- strip punctuation when matching keywords
- ensure template parsing also returns canonical values
- update field-update logic to use the same normalization helpers
- add tests covering normalization of template data

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687df332a64c832483b35c66fce79ff9