### PR TITLE
Replace magic strings with enum states

### DIFF
--- a/states.py
+++ b/states.py
@@ -1,0 +1,6 @@
+from enum import Enum, auto
+
+class ConversationState(Enum):
+    WAITING_FOR_PARTICIPANT = auto()
+    CONFIRMING_PARTICIPANT = auto()
+    CONFIRMING_DUPLICATE = auto()


### PR DESCRIPTION
## Summary
- add `ConversationState` enum for dialog states
- use enum constants in `main.py` instead of string keys

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dfc56b6d483248515e36de3a89793