### PR TITLE
Refactor add command with ConversationHandler

### DIFF
--- a/states.py
+++ b/states.py
@@ -1,6 +1,4 @@
-from enum import Enum, auto
-
-class ConversationState(Enum):
-    WAITING_FOR_PARTICIPANT = auto()
-    CONFIRMING_PARTICIPANT = auto()
-    CONFIRMING_DUPLICATE = auto()
+# states.py
+# Определяем состояния для ConversationHandler
+# Числа выбраны произвольно, главное, чтобы они были уникальны
+GETTING_DATA, CONFIRMING_DATA, CONFIRMING_DUPLICATE = range(3)


### PR DESCRIPTION
## Summary
- refactor `states.py` to simple numeric constants
- split add flow into ConversationHandler steps
- add new `get_participant_data` handler
- register conversation in `main.py`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e01464bf08324994691567cebb2b3