### PR TITLE
Fix confirmation handler parameter mismatch

### DIFF
--- a/main.py
+++ b/main.py
@@ -365,8 +365,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def handle_participant_confirmation(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
-    text: str,
 ) -> int:
+    text = update.message.text.strip()
     logger.info("User %s confirmation message: %s", update.effective_user.id, text)
 
     field_to_edit = context.user_data.get('field_to_edit')


### PR DESCRIPTION
## Summary
- remove unused `text` parameter from `handle_participant_confirmation`
- fetch message text from `update`

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_687e14cef7048324bccb7e4e1e6d543f