### PR TITLE
Fix normalization when editing fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from parsers.participant_parser import (
     parse_participant_data,
     is_template_format,
     parse_template_format,
+    normalize_field_value,
 )
 from services.participant_service import (
     merge_participant_data,
@@ -372,10 +373,16 @@ async def handle_participant_confirmation(
     field_to_edit = context.user_data.get('field_to_edit')
     if field_to_edit:
         new_value = text.strip()
-        context.user_data['parsed_participant'][field_to_edit] = new_value
+        participant_data = context.user_data.get('parsed_participant', {})
+
+        normalized_value = normalize_field_value(field_to_edit, new_value)
+
+        participant_data[field_to_edit] = normalized_value
+
+        context.user_data['parsed_participant'] = participant_data
         context.user_data.pop('field_to_edit')
 
-        await show_confirmation(update, context.user_data['parsed_participant'])
+        await show_confirmation(update, participant_data)
         return CONFIRMING_DATA
     # Если пользователь прислал блок подтверждения целиком
     if is_template_format(text):

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -508,3 +508,24 @@ def parse_participant_data(text: str, is_update: bool = False) -> Dict:
     """Извлекает данные участника из произвольного текста."""
     parser = ParticipantParser()
     return parser.parse(text, is_update)
+
+
+def normalize_field_value(field_name: str, value: str) -> str:
+    """Нормализует одно значение для указанного поля."""
+    value = value.strip()
+
+    if field_name == 'Department':
+        dept_keywords = cache.get("departments") or {}
+        return _norm_department(value, dept_keywords) or value
+
+    if field_name == 'Gender':
+        return _norm_gender(value) or value
+
+    if field_name == 'Size':
+        return _norm_size(value) or value
+
+    if field_name == 'Role':
+        return _norm_role(value) or value
+
+    return value
+


### PR DESCRIPTION
## Summary
- add `normalize_field_value` helper to `participant_parser`
- integrate normalization during edit confirmations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e177a339883248b96b9d8231c4d5d