### PR TITLE
Fix dictionary field normalization

### DIFF
--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -516,16 +516,16 @@ def normalize_field_value(field_name: str, value: str) -> str:
 
     if field_name == 'Department':
         dept_keywords = cache.get("departments") or {}
-        return _norm_department(value, dept_keywords) or value
+        return _norm_department(value, dept_keywords) or ''
 
     if field_name == 'Gender':
-        return _norm_gender(value) or value
+        return _norm_gender(value) or ''
 
     if field_name == 'Size':
-        return _norm_size(value) or value
+        return _norm_size(value) or ''
 
     if field_name == 'Role':
-        return _norm_role(value) or value
+        return _norm_role(value) or ''
 
     return value
 

--- a/tests/test_normalize_field_value.py
+++ b/tests/test_normalize_field_value.py
@@ -1,0 +1,33 @@
+import unittest
+from parsers.participant_parser import normalize_field_value
+from utils.cache import load_reference_data
+
+load_reference_data()
+
+class NormalizeFieldValueTestCase(unittest.TestCase):
+    def test_unknown_department(self):
+        self.assertEqual(normalize_field_value('Department', 'лалалал'), '')
+
+    def test_unknown_gender(self):
+        self.assertEqual(normalize_field_value('Gender', 'неизвестно'), '')
+
+    def test_unknown_size(self):
+        self.assertEqual(normalize_field_value('Size', 'большой'), '')
+
+    def test_unknown_role(self):
+        self.assertEqual(normalize_field_value('Role', 'работник'), '')
+
+    def test_known_department_synonym(self):
+        self.assertEqual(normalize_field_value('Department', 'админ'), 'Administration')
+
+    def test_known_gender_synonym(self):
+        self.assertEqual(normalize_field_value('Gender', 'муж'), 'M')
+
+    def test_known_size_synonym(self):
+        self.assertEqual(normalize_field_value('Size', 'medium'), 'M')
+
+    def test_known_role_synonym(self):
+        self.assertEqual(normalize_field_value('Role', 'тим'), 'TEAM')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `normalize_field_value` to return empty string when input isn't recognized
- add tests covering normalization for dictionary-backed fields

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1b22dd308324831f329336eb8280