### PR TITLE
Fix Role normalization

### DIFF
--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -525,7 +525,7 @@ def normalize_field_value(field_name: str, value: str) -> str:
         return _norm_size(value) or ''
 
     if field_name == 'Role':
-        return _norm_role(value) or ''
+        return _norm_role(value) or 'CANDIDATE'
 
     return value
 

--- a/tests/test_normalize_field_value.py
+++ b/tests/test_normalize_field_value.py
@@ -15,7 +15,7 @@ class NormalizeFieldValueTestCase(unittest.TestCase):
         self.assertEqual(normalize_field_value('Size', 'большой'), '')
 
     def test_unknown_role(self):
-        self.assertEqual(normalize_field_value('Role', 'работник'), '')
+        self.assertEqual(normalize_field_value('Role', 'работник'), 'CANDIDATE')
 
     def test_known_department_synonym(self):
         self.assertEqual(normalize_field_value('Department', 'админ'), 'Administration')


### PR DESCRIPTION
## Summary
- fix Role default value to `CANDIDATE` when unrecognized
- update tests accordingly

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e26d056c8832491d0ba1065b66b15