### PR TITLE
Improve parsing of unstructured participant data

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from parsers.participant_parser import (
     parse_participant_data,
     is_template_format,
     parse_template_format,
+    parse_unstructured_text,
     normalize_field_value,
 )
 from services.participant_service import (
@@ -210,10 +211,14 @@ async def handle_partial_data(update: Update, context: ContextTypes.DEFAULT_TYPE
     text = update.message.text.strip()
     participant_data = context.user_data.get('add_flow_data', {})
 
-    parsed_update = parse_participant_data(text, is_update=True)
+    parsed_update = {}
 
     if is_template_format(text):
         parsed_update = parse_template_format(text)
+    elif ':' in text:
+        parsed_update = parse_participant_data(text, is_update=True)
+    else:
+        parsed_update = parse_unstructured_text(text)
 
     for key, value in parsed_update.items():
         if value:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,8 +3,9 @@ from parsers.participant_parser import (
     parse_participant_data,
     is_template_format,
     parse_template_format,
+    parse_unstructured_text,
 )
-from utils.cache import load_reference_data
+from utils.cache import load_reference_data, cache
 
 load_reference_data()
 
@@ -128,6 +129,16 @@ class ParserTestCase(unittest.TestCase):
         ])
         data = parse_participant_data(text)
         self.assertEqual(data['Department'], '')
+
+    def test_unstructured_multi_field(self):
+        cache.set('churches', ['Грейс'])
+        text = "Саша Б тим админ Грейс Хайфа"
+        data = parse_unstructured_text(text)
+        self.assertEqual(data['FullNameRU'], 'Саша Б')
+        self.assertEqual(data['Role'], 'TEAM')
+        self.assertEqual(data['Department'], 'Administration')
+        self.assertEqual(data['Church'], 'Грейс')
+        self.assertEqual(data['CountryAndCity'], 'ХАЙФА')
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/recognizers.py
+++ b/utils/recognizers.py
@@ -1,0 +1,66 @@
+from typing import Optional
+from utils.cache import cache
+
+ROLE_MAP = {
+    'тим': 'TEAM', 'команда': 'TEAM', 'team': 'TEAM',
+    'участник': 'Participant', 'кандидат': 'Participant', 'participant': 'Participant'
+}
+
+GENDER_MAP = {
+    'м': 'M', 'm': 'M', 'муж': 'M', 'мужской': 'M',
+    'ж': 'F', 'f': 'F', 'жен': 'F', 'женский': 'F'
+}
+
+SIZE_MAP = {
+    'xs': 'XS', 's': 'S', 'm': 'M', 'l': 'L', 'xl': 'XL', 'xxl': 'XXL',
+    'хс': 'XS', 'с': 'S', 'м': 'M', 'л': 'L', 'хл': 'XL', 'ххл': 'XXL'
+}
+
+DEPARTMENT_MAP = {
+    'админ': 'Administration', 'администрация': 'Administration',
+    'кухня': 'Kitchen',
+    'прославление': 'Worship', 'воршип': 'Worship',
+}
+
+
+def get_reference_data(key: str):
+    return cache.get(key) or []
+
+
+def recognize_role(token: str) -> Optional[str]:
+    return ROLE_MAP.get(token.lower())
+
+
+def recognize_gender(token: str) -> Optional[str]:
+    return GENDER_MAP.get(token.lower())
+
+
+def recognize_size(token: str) -> Optional[str]:
+    return SIZE_MAP.get(token.lower())
+
+
+def recognize_department(token: str) -> Optional[str]:
+    for alias, standard in DEPARTMENT_MAP.items():
+        if alias in token.lower():
+            return standard
+    return None
+
+
+def recognize_church(token: str) -> Optional[str]:
+    if len(token) < 3:
+        return None
+    churches = get_reference_data('churches')
+    for church_name in churches:
+        if token.lower() in church_name.lower():
+            return church_name
+    return None
+
+
+def recognize_city(token: str) -> Optional[str]:
+    if len(token) < 3:
+        return None
+    cities = get_reference_data('cities')
+    for city_name in cities:
+        if token.lower() in city_name.lower():
+            return city_name
+    return None


### PR DESCRIPTION
## Summary
- add new `recognizers` module for keyword matching
- implement `parse_unstructured_text` to extract multiple fields from a free-form line
- integrate new parser into `/add` flow
- fix priority in `handle_partial_data` to avoid overwriting recognized fields
- update tests for new parser logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3c35b12c8324857a7904c781cf23