### PR TITLE
Fix candidate department logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ CLAUDE.md
 
 # Logs
 *.log
+*.tgz

--- a/main.py
+++ b/main.py
@@ -320,7 +320,9 @@ async def list_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     for p in participants:
         role_emoji = "👤" if p.Role == 'CANDIDATE' else "👨‍💼"
-        department = f" ({p.Department})" if p.Department else ""
+        department = (
+            f" ({p.Department})" if p.Role == 'TEAM' and p.Department else ""
+        )
 
         message += f"{role_emoji} **{p.FullNameRU}**\n"
         message += f"   • Роль: {p.Role}{department}\n"

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 CHURCH_KEYWORDS = ['ЦЕРКОВЬ', 'CHURCH', 'ХРАМ', 'ОБЩИНА']
 
 # Punctuation characters to strip when normalizing tokens
-PUNCTUATION_CHARS = '.,!?:;'
+# Added quotes to clean up inputs like "worship" or 'worship'
+PUNCTUATION_CHARS = '.,!?:;\'"'
 
 # Mapping of size synonyms to their canonical values
 SIZE_KEYWORDS_MAP = {

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -138,6 +138,9 @@ class ParticipantService:
         if not valid:
             raise ValidationError(error)
 
+        if data.get('Role') == 'CANDIDATE':
+            data['Department'] = None
+
         existing = await self.check_duplicate(data.get("FullNameRU", ""))
         if existing:
             raise DuplicateParticipantError(
@@ -152,5 +155,8 @@ class ParticipantService:
         valid, error = validate_participant_data(data)
         if not valid:
             raise ValidationError(error)
+
+        if data.get('Role') == 'CANDIDATE':
+            data['Department'] = None
 
         return self.repository.update(participant_id, data)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,6 +24,11 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(data['Role'], 'TEAM')
         self.assertEqual(data['Department'], 'Worship')
 
+    def test_parse_department_with_quotes(self):
+        text = "Иван Петров M команда 'worship'"
+        data = parse_participant_data(text)
+        self.assertEqual(data['Department'], 'Worship')
+
     def test_russian_size_and_gender_priority(self):
         text = "Ольга Сергеевна жен М Афула церковь Благодать"
         data = parse_participant_data(text)

--- a/tests/test_participant_service.py
+++ b/tests/test_participant_service.py
@@ -1,0 +1,72 @@
+import unittest
+import sqlite3
+import asyncio
+
+import database
+from database import init_database, get_participant_by_id
+from repositories.participant_repository import SqliteParticipantRepository
+from services.participant_service import ParticipantService
+
+
+database.DB_PATH = ":memory:"
+
+class ParticipantServiceTestCase(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(database.DB_PATH)
+        self.conn.row_factory = sqlite3.Row
+        self._orig_enter = database.DatabaseConnection.__enter__
+        self._orig_exit = database.DatabaseConnection.__exit__
+
+        def _enter(_self):
+            _self.conn = self.conn
+            return self.conn
+
+        def _exit(_self, exc_type, exc_val, exc_tb):
+            if exc_type:
+                self.conn.rollback()
+            else:
+                self.conn.commit()
+        database.DatabaseConnection.__enter__ = _enter
+        database.DatabaseConnection.__exit__ = _exit
+
+        init_database()
+        repo = SqliteParticipantRepository()
+        self.service = ParticipantService(repository=repo)
+
+    def tearDown(self):
+        database.DatabaseConnection.__enter__ = self._orig_enter
+        database.DatabaseConnection.__exit__ = self._orig_exit
+        self.conn.close()
+
+    def test_candidate_department_cleared_on_add(self):
+        data = {
+            'FullNameRU': 'User A',
+            'Gender': 'M',
+            'Size': 'L',
+            'Church': 'Test',
+            'Role': 'CANDIDATE',
+            'Department': 'Worship',
+        }
+        participant_id = asyncio.run(self.service.add_participant(data))
+        row = get_participant_by_id(participant_id)
+        self.assertIsNone(row['Department'])
+
+    def test_candidate_department_cleared_on_update(self):
+        start = {
+            'FullNameRU': 'User B',
+            'Gender': 'F',
+            'Size': 'S',
+            'Church': 'Test',
+            'Role': 'TEAM',
+            'Department': 'Media',
+        }
+        pid = asyncio.run(self.service.add_participant(start))
+        update = {'Role': 'CANDIDATE', 'Department': 'Media', 'FullNameRU': 'User B', 'Gender': 'F', 'Size': 'S', 'Church': 'Test'}
+        asyncio.run(self.service.update_participant(pid, update))
+        row = get_participant_by_id(pid)
+        self.assertEqual(row['Role'], 'CANDIDATE')
+        self.assertIsNone(row['Department'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ignore `.tgz` archives
- clean quotes when normalizing tokens
- hide department for candidates in `/list`
- strip department on add/update when role is `CANDIDATE`
- test new behaviour

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_687e5d54b94483249b7416d327dbbfff