### PR TITLE
Fix candidate department handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -320,7 +320,7 @@ async def list_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     for p in participants:
         role_emoji = "👤" if p.Role == 'CANDIDATE' else "👨‍💼"
-        department = f" ({p.Department})" if p.Department else ""
+        department = f" ({p.Department})" if p.Role == 'TEAM' and p.Department else ""
 
         message += f"{role_emoji} **{p.FullNameRU}**\n"
         message += f"   • Роль: {p.Role}{department}\n"

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -134,6 +134,9 @@ class ParticipantService:
 
     def add_participant(self, data: Dict) -> int:
         """Validate data, check for duplicates and save participant."""
+        if data.get('Role') == 'CANDIDATE':
+            data['Department'] = ''
+
         valid, error = validate_participant_data(data)
         if not valid:
             raise ValidationError(error)
@@ -149,6 +152,9 @@ class ParticipantService:
 
     def update_participant(self, participant_id: int, data: Dict) -> bool:
         """Validate and update participant."""
+        if data.get('Role') == 'CANDIDATE':
+            data['Department'] = ''
+
         valid, error = validate_participant_data(data)
         if not valid:
             raise ValidationError(error)


### PR DESCRIPTION
## Summary
- skip department for non-TEAM participants in `/list`
- clear department when adding or updating a candidate

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_687f7b05d5348324bb9f78507a026bfc