### PR TITLE
Fix inconsistency when fetching participant by ID

### DIFF
--- a/database.py
+++ b/database.py
@@ -9,6 +9,36 @@ from utils.exceptions import (
     ValidationError,
 )
 
+"""
+===============================================================================
+ПРАВИЛА ОБРАБОТКИ ИСКЛЮЧЕНИЙ В DATABASE LAYER
+===============================================================================
+
+🔍 ФУНКЦИИ ПОИСКА (get_*, find_*):
+    - Возвращают None если запись не найдена
+    - Бросают BotException только при реальных ошибках БД (connection, syntax, etc.)
+    - НЕ бросают ParticipantNotFoundError
+
+📝 ФУНКЦИИ ИЗМЕНЕНИЯ (add_*, update_*, delete_*):
+    - Бросают ParticipantNotFoundError если запись не найдена для изменения
+    - Бросают ValidationError при нарушении ограничений БД
+    - Бросают BotException при ошибках БД
+
+✅ ПРИМЕРЫ:
+    get_participant_by_id(999) -> None (не найден)
+    update_participant(999, data) -> ParticipantNotFoundError (не найден для изменения)
+    add_participant(invalid_data) -> ValidationError (нарушены ограничения)
+
+    # Правильное использование:
+    participant = get_participant_by_id(123)
+    if participant is None:
+        print("Не найден")
+    else:
+        print(f"Найден: {participant['FullNameRU']}")
+        
+===============================================================================
+"""
+
 DB_PATH = "participants.db"
 logger = logging.getLogger(__name__)
 
@@ -152,6 +182,18 @@ def get_all_participants() -> List[Dict]:
 
 
 def get_participant_by_id(participant_id: int) -> Optional[Dict]:
+    """
+    ✅ ИСПРАВЛЕНО: возвращает None вместо исключения, если участник не найден.
+
+    Args:
+        participant_id: ID участника для поиска
+
+    Returns:
+        Dict с данными участника или None, если не найден
+
+    Raises:
+        BotException: При ошибках базы данных (но НЕ при "не найдено")
+    """
     try:
         with DatabaseConnection() as conn:
             cursor = conn.cursor()
@@ -161,16 +203,45 @@ def get_participant_by_id(participant_id: int) -> Optional[Dict]:
             )
             row = cursor.fetchone()
             if not row:
-                raise ParticipantNotFoundError(
-                    f"Participant with id {participant_id} not found"
-                )
+                logger.debug(f"Participant with id {participant_id} not found")
+                return None
             return dict(row)
     except sqlite3.Error as e:
-        logger.error("Database error while fetching participant: %s", e)
+        logger.error(
+            "Database error while fetching participant by ID %s: %s",
+            participant_id,
+            e,
+        )
         raise BotException("Database error while fetching participant") from e
 
 
+def get_participant_by_id_safe(participant_id: int, context: str = "") -> Optional[Dict]:
+    """
+    ✅ НОВАЯ ФУНКЦИЯ: безопасное получение участника с контекстным логированием.
+
+    Args:
+        participant_id: ID участника
+        context: Контекст вызова для логирования (например, "update_participant")
+
+    Returns:
+        Dict с данными участника или None
+    """
+    participant = get_participant_by_id(participant_id)
+    if participant is None:
+        logger.warning(
+            f"Participant {participant_id} not found in context: {context or 'unknown'}"
+        )
+    else:
+        logger.debug(
+            f"Found participant {participant_id} ({participant.get('FullNameRU', 'unnamed')}) "
+            f"in context: {context or 'unknown'}"
+        )
+    return participant
+
+
 def update_participant(participant_id: int, participant_data: Dict) -> bool:
+    """Update a participant or raise ParticipantNotFoundError if missing."""
+
     participant_data = _truncate_fields(participant_data)
     try:
         with DatabaseConnection() as conn:

--- a/repositories/participant_repository.py
+++ b/repositories/participant_repository.py
@@ -45,7 +45,6 @@ from database import (
     get_all_participants,
     update_participant
 )
-from utils.exceptions import ParticipantNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -59,11 +58,19 @@ class SqliteParticipantRepository(AbstractParticipantRepository):
         return add_participant(participant_data)
 
     def get_by_id(self, participant_id: int) -> Optional[Participant]:
+        """
+        ✅ ИСПРАВЛЕНО: теперь корректно обрабатывает None от database функции.
+        """
         logger.info(f"Getting participant by ID from SQLite: {participant_id}")
+
         participant_dict = get_participant_by_id(participant_id)
-        if participant_dict:
-            return Participant(**{k: v for k, v in participant_dict.items() if k in Participant.__annotations__})
-        return None
+
+        if participant_dict is None:
+            logger.debug(f"Participant {participant_id} not found in database")
+            return None
+
+        valid_fields = {k: v for k, v in participant_dict.items() if k in Participant.__annotations__}
+        return Participant(**valid_fields)
 
     def get_by_name(self, full_name_ru: str) -> Optional[Participant]:
         logger.info(f"Getting participant by name from SQLite: {full_name_ru}")

--- a/tests/test_database_fix.py
+++ b/tests/test_database_fix.py
@@ -1,0 +1,61 @@
+import unittest
+import sqlite3
+
+from database import (
+    get_participant_by_id,
+    find_participant_by_name,
+    init_database,
+)
+from repositories.participant_repository import SqliteParticipantRepository
+
+import database
+
+database.DB_PATH = ":memory:"
+
+
+class MissingLookupReturnsNoneTestCase(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(database.DB_PATH)
+        self.conn.row_factory = sqlite3.Row
+        self._original_enter = database.DatabaseConnection.__enter__
+        self._original_exit = database.DatabaseConnection.__exit__
+
+        def _enter(_self):
+            _self.conn = self.conn
+            return self.conn
+
+        def _exit(_self, exc_type, exc_val, exc_tb):
+            if exc_type:
+                self.conn.rollback()
+            else:
+                self.conn.commit()
+
+        database.DatabaseConnection.__enter__ = _enter
+        database.DatabaseConnection.__exit__ = _exit
+
+        init_database()
+
+    def tearDown(self):
+        database.DatabaseConnection.__enter__ = self._original_enter
+        database.DatabaseConnection.__exit__ = self._original_exit
+        self.conn.close()
+
+    def test_get_participant_by_id_none(self):
+        result = get_participant_by_id(99999)
+        print(f"get_participant_by_id(99999): {result}")
+        self.assertIsNone(result)
+
+    def test_find_participant_by_name_none(self):
+        result = find_participant_by_name("Несуществующий Участник")
+        print(f"find_participant_by_name: {result}")
+        self.assertIsNone(result)
+
+    def test_repository_get_by_id_none(self):
+        repo = SqliteParticipantRepository()
+        result = repo.get_by_id(99999)
+        print(f"repo.get_by_id(99999): {result}")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- unify behavior of `get_participant_by_id` to return `None` when not found
- add `get_participant_by_id_safe` wrapper with contextual logging
- update repository `get_by_id` to handle `None`
- document `update_participant` behavior
- document exception policy in `database.py`
- add regression test for missing lookups

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_687fb4c5ff288324b63faee907892971