### PR TITLE
feat: centralize field mappings

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,60 +1,66 @@
 from enum import Enum
 
+
 class Gender(Enum):
-    MALE = 'M'
-    FEMALE = 'F'
+    MALE = "M"
+    FEMALE = "F"
+
 
 class Role(Enum):
-    CANDIDATE = 'CANDIDATE'
-    TEAM = 'TEAM'
+    CANDIDATE = "CANDIDATE"
+    TEAM = "TEAM"
 
-GENDER_KEYWORDS = {
-    Gender.MALE.value: ['M', 'МУЖ', 'МУЖСКОЙ', 'MALE', 'М', 'МУЖЧИНА'],
-    Gender.FEMALE.value: ['F', 'ЖЕН', 'ЖЕНСКИЙ', 'FEMALE', 'Ж', 'ЖЕНЩИНА']
-}
-
-ROLE_KEYWORDS = {
-    Role.TEAM.value: ['TEAM', 'КОМАНДА', 'ТИМ', 'TIM', 'TEAM MEMBER', 'ЧЛЕН КОМАНДЫ', 'КОМАНДНЫЙ', 'СЛУЖИТЕЛЬ'],
-    Role.CANDIDATE.value: ['CANDIDATE', 'КАНДИДАТ', 'УЧАСТНИК', 'КАНДИДАТКА']
-}
-
-DEPARTMENT_KEYWORDS = {
-    'ROE': [
-        'ROE', 'РОЕ', 'ROE ROOM', 'РОЕ РУМ', 'РОЭ', 'РОИ',
-        'roe', 'рое', 'roe room', 'рое рум', 'роэ'
-    ],
-    'Chapel': ['CHAPEL', 'МОЛИТВЕННЫЙ', 'МОЛИТВА', 'PRAYER', 'ЧАСОВНЯ'],
-    'Setup': ['SETUP', 'СЕТАП', 'НАСТРОЙКА', 'ПОДГОТОВКА', 'СЕТ АП'],
-    'Palanka': ['PALANKA', 'ПАЛАНКА', 'ПОЛАНКА'],
-    'Administration': ['ADMINISTRATION', 'АДМИНИСТРАЦИЯ', 'АДМИН', 'ADMIN', 'УПРАВЛЕНИЕ'],
-    'Kitchen': ['KITCHEN', 'КУХНЯ', 'КИТЧЕН', 'КУЛИНАРИЯ', 'ПОВАРА'],
-    'Decoration': ['DECORATION', 'ДЕКОРАЦИИ', 'ДЕКОР', 'DECO', 'DECOR', 'УКРАШЕНИЕ', 'ОФОРМЛЕНИЕ'],
-    'Bell': ['BELL', 'ЗВОНАРЬ', 'БЕЛЛ', 'ЗВОН', 'КОЛОКОЛЬЧИК'],
-    'Refreshment': ['REFRESHMENT', 'РЕФРЕШМЕНТ', 'УГОЩЕНИЯ', 'НАПИТКИ'],
-    'Worship': ['WORSHIP', 'ПРОСЛАВЛЕНИЕ', 'ВОРШИП', 'МУЗЫКА', 'MUSIC'],
-    'Media': ['MEDIA', 'МЕДИА', 'ВИДЕО', 'ФОТО', 'СЪЕМКА', 'КАМЕРА', 'ФОТОГРАФ'],
-    'Духовенство': ['ДУХОВЕНСТВО', 'CLERGY', 'СВЯЩЕННИКИ'],
-    'Ректорат': ['РЕКТОРАТ', 'RECTOR', 'РЕКТОРЫ']
-}
-
-SIZES = [
-    'XS', 'EXTRA SMALL', 'EXTRASMALL',
-    'S', 'SMALL',
-    'M', 'MEDIUM',
-    'L', 'LARGE',
-    'XL', 'EXTRA LARGE', 'EXTRALARGE',
-    'XXL', '2XL', 'EXTRA EXTRA LARGE',
-    '3XL', 'XXXL'
-]
 
 ISRAEL_CITIES = [
-    'ХАЙФА', 'HAIFA', 'ТЕЛ-АВИВ', 'TEL AVIV', 'ТЕЛЬ-АВИВ', 'ИЕРУСАЛИМ', 'JERUSALEM',
-    'БЕЭР-ШЕВА', 'BEER SHEVA', 'НЕТАНИЯ', 'NETANYA', 'АШДОД', 'ASHDOD',
-    'РИШОН-ЛЕ-ЦИОН', 'РИШОН ЛЕ ЦИОН', 'РИШОН-ЛЕ ЦИОН', 'РИШОН ЛЕЦИОН',
-    'RISHON LEZION', 'RISHON-LEZION', 'RISHON LE ZION', 'RISHON-LE ZION',
-    'ПЕТАХ-ТИКВА', 'PETAH TIKVA', 'РЕХОВОТ', 'REHOVOT',
-    'БАТ-ЯМ', 'BAT YAM', 'КАРМИЭЛЬ', 'CARMIEL', 'МОДИИН', 'MODIIN', 'НАЗАРЕТ', 'NAZARETH',
-    'КИРЬЯТ-ГАТ', 'KIRYAT GAT', 'ЭЙЛАТ', 'EILAT', 'АККО', 'ACRE', 'РАМАТ-ГАН', 'RAMAT GAN',
-    'БНЕЙ-БРАК', 'BNEI BRAK', 'ЦФАТ', 'SAFED', 'ТВЕРИЯ', 'TIBERIAS', 'ГЕРЦЛИЯ', 'HERZLIYA',
-    'АФУЛА', 'AFULA'
+    "ХАЙФА",
+    "HAIFA",
+    "ТЕЛ-АВИВ",
+    "TEL AVIV",
+    "ТЕЛЬ-АВИВ",
+    "ИЕРУСАЛИМ",
+    "JERUSALEM",
+    "БЕЭР-ШЕВА",
+    "BEER SHEVA",
+    "НЕТАНИЯ",
+    "NETANYA",
+    "АШДОД",
+    "ASHDOD",
+    "РИШОН-ЛЕ-ЦИОН",
+    "РИШОН ЛЕ ЦИОН",
+    "РИШОН-ЛЕ ЦИОН",
+    "РИШОН ЛЕЦИОН",
+    "RISHON LEZION",
+    "RISHON-LEZION",
+    "RISHON LE ZION",
+    "RISHON-LE ZION",
+    "ПЕТАХ-ТИКВА",
+    "PETAH TIKVA",
+    "РЕХОВОТ",
+    "REHOVOT",
+    "БАТ-ЯМ",
+    "BAT YAM",
+    "КАРМИЭЛЬ",
+    "CARMIEL",
+    "МОДИИН",
+    "MODIIN",
+    "НАЗАРЕТ",
+    "NAZARETH",
+    "КИРЬЯТ-ГАТ",
+    "KIRYAT GAT",
+    "ЭЙЛАТ",
+    "EILAT",
+    "АККО",
+    "ACRE",
+    "РАМАТ-ГАН",
+    "RAMAT GAN",
+    "БНЕЙ-БРАК",
+    "BNEI BRAK",
+    "ЦФАТ",
+    "SAFED",
+    "ТВЕРИЯ",
+    "TIBERIAS",
+    "ГЕРЦЛИЯ",
+    "HERZLIYA",
+    "АФУЛА",
+    "AFULA",
 ]

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -2,12 +2,12 @@ from typing import Dict, Optional, List
 import re
 import logging
 
-from constants import (
-    GENDER_KEYWORDS,
-    ROLE_KEYWORDS,
-    SIZES,
-    Gender,
-    Role,
+from utils.field_normalizer import (
+    field_normalizer,
+    normalize_gender,
+    normalize_role,
+    normalize_size,
+    normalize_department,
 )
 from utils.cache import cache
 from utils.recognizers import (
@@ -21,99 +21,94 @@ from utils.recognizers import (
 
 logger = logging.getLogger(__name__)
 
-CHURCH_KEYWORDS = ['ЦЕРКОВЬ', 'CHURCH', 'ХРАМ', 'ОБЩИНА']
+CHURCH_KEYWORDS = ["ЦЕРКОВЬ", "CHURCH", "ХРАМ", "ОБЩИНА"]
 
 # Punctuation characters to strip when normalizing tokens
-PUNCTUATION_CHARS = '.,!?:;'
+PUNCTUATION_CHARS = ".,!?:;"
 
-# Mapping of size synonyms to their canonical values
-SIZE_KEYWORDS_MAP = {
-    'XS': {'XS', 'EXTRA SMALL', 'EXTRASMALL'},
-    'S': {'S', 'SMALL'},
-    'M': {'M', 'MEDIUM'},
-    'L': {'L', 'LARGE'},
-    'XL': {'XL', 'EXTRA LARGE', 'EXTRALARGE'},
-    'XXL': {'XXL', '2XL', 'EXTRA EXTRA LARGE'},
-    '3XL': {'3XL', 'XXXL'},
+# Pre-computed synonym sets for performance
+GENDER_SYNONYMS = {
+    syn.upper()
+    for synonyms in field_normalizer.GENDER_MAPPINGS.values()
+    for syn in synonyms
+}
+SIZE_SYNONYMS = {
+    syn.upper()
+    for synonyms in field_normalizer.SIZE_MAPPINGS.values()
+    for syn in synonyms
+}
+ROLE_SYNONYMS = {
+    syn.upper()
+    for synonyms in field_normalizer.ROLE_MAPPINGS.values()
+    for syn in synonyms
 }
 
 
-def _norm_token(token: str) -> str:
-    """Strip punctuation and convert to upper case."""
-    return token.strip(PUNCTUATION_CHARS).upper()
-
-
-NORMALIZED_SIZES = {_norm_token(s) for synonyms in SIZE_KEYWORDS_MAP.values() for s in synonyms}
-
-
-def _norm_gender(value: str) -> Optional[str]:
-    val = _norm_token(value)
-    if val in GENDER_KEYWORDS['M']:
-        return 'M'
-    if val in GENDER_KEYWORDS['F']:
-        return 'F'
-    return None
-
-
-def _norm_role(value: str) -> Optional[str]:
-    val = _norm_token(value)
-    if val in ROLE_KEYWORDS['TEAM']:
-        return 'TEAM'
-    if val in ROLE_KEYWORDS['CANDIDATE']:
-        return 'CANDIDATE'
-    return None
-
-
-def _norm_department(value: str, dept_keywords: Dict[str, list]) -> Optional[str]:
-    val = _norm_token(value)
-    for dept, keys in dept_keywords.items():
-        if val in [k.upper() for k in keys]:
-            return dept
-    return None
-
-
-def _norm_size(value: str) -> Optional[str]:
-    val = _norm_token(value)
-    for canon, keys in SIZE_KEYWORDS_MAP.items():
-        if val in {k.upper() for k in keys}:
-            return canon
-    return None
-
 # Служебные слова, которые встречаются в блоке подтверждения
 CONFIRMATION_NOISE_WORDS = {
-    'ВОТ', 'ЧТО', 'Я', 'ПОНЯЛ', 'ИЗ', 'ВАШИХ', 'ДАННЫХ', 'ИМЯ', 'РУС', 'АНГЛ',
-    'ПОЛ', 'РАЗМЕР', 'ГОРОД', 'КТО', 'ПОДАЛ', 'КОНТАКТЫ', 'НЕ', 'УКАЗАНО', 'РОЛЬ',
-    'ДЕПАРТАМЕНТ', 'ВСЕГО', 'ПРАВИЛЬНО', 'ОТПРАВЬТЕ', 'ДА', 'ДЛЯ', 'СОХРАНЕНИЯ',
-    'НЕТ', 'ОТМЕНЫ', 'ИЛИ', 'ПРИШЛИТЕ', 'ИСПРАВЛЕННЫЕ', 'ПО', 'ТЕМПЛЕЙТУ',
-    'ПОЛНОЙ', 'CANCEL'
+    "ВОТ",
+    "ЧТО",
+    "Я",
+    "ПОНЯЛ",
+    "ИЗ",
+    "ВАШИХ",
+    "ДАННЫХ",
+    "ИМЯ",
+    "РУС",
+    "АНГЛ",
+    "ПОЛ",
+    "РАЗМЕР",
+    "ГОРОД",
+    "КТО",
+    "ПОДАЛ",
+    "КОНТАКТЫ",
+    "НЕ",
+    "УКАЗАНО",
+    "РОЛЬ",
+    "ДЕПАРТАМЕНТ",
+    "ВСЕГО",
+    "ПРАВИЛЬНО",
+    "ОТПРАВЬТЕ",
+    "ДА",
+    "ДЛЯ",
+    "СОХРАНЕНИЯ",
+    "НЕТ",
+    "ОТМЕНЫ",
+    "ИЛИ",
+    "ПРИШЛИТЕ",
+    "ИСПРАВЛЕННЫЕ",
+    "ПО",
+    "ТЕМПЛЕЙТУ",
+    "ПОЛНОЙ",
+    "CANCEL",
 }
 
 # Подсказки для определения поля при исправлении
 FIELD_INDICATORS = {
-    'Gender': ['ПОЛ', 'GENDER'],
-    'Size': ['РАЗМЕР', 'SIZE'],
-    'Role': ['РОЛЬ', 'ROLE'],
-    'Department': ['ДЕПАРТАМЕНТ', 'DEPARTMENT'],
-    'Church': ['ЦЕРКОВЬ', 'CHURCH'],
-    'FullNameRU': ['ИМЯ', 'РУССКИЙ', 'NAME'],
-    'FullNameEN': ['АНГЛИЙСКИЙ', 'ENGLISH', 'АНГЛ'],
-    'CountryAndCity': ['ГОРОД', 'CITY', 'СТРАНА'],
-    'SubmittedBy': ['ПОДАЛ', 'SUBMITTED'],
-    'ContactInformation': ['КОНТАКТ', 'ТЕЛЕФОН', 'EMAIL', 'PHONE']
+    "Gender": ["ПОЛ", "GENDER"],
+    "Size": ["РАЗМЕР", "SIZE"],
+    "Role": ["РОЛЬ", "ROLE"],
+    "Department": ["ДЕПАРТАМЕНТ", "DEPARTMENT"],
+    "Church": ["ЦЕРКОВЬ", "CHURCH"],
+    "FullNameRU": ["ИМЯ", "РУССКИЙ", "NAME"],
+    "FullNameEN": ["АНГЛИЙСКИЙ", "ENGLISH", "АНГЛ"],
+    "CountryAndCity": ["ГОРОД", "CITY", "СТРАНА"],
+    "SubmittedBy": ["ПОДАЛ", "SUBMITTED"],
+    "ContactInformation": ["КОНТАКТ", "ТЕЛЕФОН", "EMAIL", "PHONE"],
 }
 
 # Поля шаблона и их соответствие ключам базы данных
 TEMPLATE_FIELD_MAP = {
-    'Имя (рус)': 'FullNameRU',
-    'Имя (англ)': 'FullNameEN',
-    'Пол': 'Gender',
-    'Размер': 'Size',
-    'Церковь': 'Church',
-    'Роль': 'Role',
-    'Департамент': 'Department',
-    'Город': 'CountryAndCity',
-    'Кто подал': 'SubmittedBy',
-    'Контакты': 'ContactInformation',
+    "Имя (рус)": "FullNameRU",
+    "Имя (англ)": "FullNameEN",
+    "Пол": "Gender",
+    "Размер": "Size",
+    "Церковь": "Church",
+    "Роль": "Role",
+    "Департамент": "Department",
+    "Город": "CountryAndCity",
+    "Кто подал": "SubmittedBy",
+    "Контакты": "ContactInformation",
 }
 
 
@@ -121,7 +116,7 @@ def is_template_format(text: str) -> bool:
     """Определяет, похоже ли сообщение на заполненный шаблон."""
     count = 0
     for field in TEMPLATE_FIELD_MAP.keys():
-        if re.search(fr'{re.escape(field)}\s*:', text, re.IGNORECASE):
+        if re.search(rf"{re.escape(field)}\s*:", text, re.IGNORECASE):
             count += 1
     result = count >= 3
     logger.debug("is_template_format=%s for text: %s", result, text)
@@ -132,32 +127,30 @@ def parse_template_format(text: str) -> Dict:
     """Парсит текст, оформленный по шаблону Ключ: Значение."""
     data: Dict = {}
     # Разделяем по переносу строк и возможным разделителям
-    parts = re.split(r'[\n;]+', text)
+    parts = re.split(r"[\n;]+", text)
     items = []
     for part in parts:
-        items.extend(part.split(','))
-
-    dept_keywords = cache.get("departments") or {}
+        items.extend(part.split(","))
 
     for item in items:
-        if ':' not in item:
+        if ":" not in item:
             continue
-        key, value = item.split(':', 1)
+        key, value = item.split(":", 1)
         key = key.strip()
         value = value.strip()
-        if value in ['➖ Не указано', '❌ Не указано']:
-            value = ''
+        if value in ["➖ Не указано", "❌ Не указано"]:
+            value = ""
         for ru, eng in TEMPLATE_FIELD_MAP.items():
             if key.lower() == ru.lower():
-                norm = value or ''
-                if eng == 'Gender':
-                    norm = _norm_gender(value) or ''
-                elif eng == 'Role':
-                    norm = _norm_role(value) or ''
-                elif eng == 'Department':
-                    norm = _norm_department(value, dept_keywords) or ''
-                elif eng == 'Size':
-                    norm = _norm_size(value) or ''
+                norm = value or ""
+                if eng == "Gender":
+                    norm = normalize_gender(value) or ""
+                elif eng == "Role":
+                    norm = normalize_role(value) or ""
+                elif eng == "Department":
+                    norm = normalize_department(value) or ""
+                elif eng == "Size":
+                    norm = normalize_size(value) or ""
                 data[eng] = norm
                 break
     logger.debug("parse_template_format parsed fields: %s", list(data.keys()))
@@ -174,18 +167,20 @@ def parse_unstructured_text(text: str) -> Dict[str, str]:
     # --- Pass 1: Match multi-word known church names (highest priority) ---
     known_churches = cache.get("churches") or []
     # Sort by number of words in name, descending, to match "Слово Жизни" before "Слово"
-    sorted_church_names = sorted(known_churches, key=lambda x: len(x.split()), reverse=True)
+    sorted_church_names = sorted(
+        known_churches, key=lambda x: len(x.split()), reverse=True
+    )
     for church_name_str in sorted_church_names:
         name_tokens = church_name_str.split()
         for i in range(len(tokens) - len(name_tokens) + 1):
             # Slice of tokens from the input to check for a match
-            chunk = tokens[i:i + len(name_tokens)]
+            chunk = tokens[i : i + len(name_tokens)]
             # Check if this chunk has already been consumed
-            if any(consumed[i:i + len(name_tokens)]):
+            if any(consumed[i : i + len(name_tokens)]):
                 continue
             # Compare lowercased tokens
             if [t.lower() for t in chunk] == [nt.lower() for nt in name_tokens]:
-                participant_data['Church'] = church_name_str.capitalize()
+                participant_data["Church"] = church_name_str.capitalize()
                 for j in range(i, i + len(name_tokens)):
                     consumed[j] = True
                 # Consume a nearby church identifier if present to avoid it ending up in the name
@@ -198,42 +193,46 @@ def parse_unstructured_text(text: str) -> Dict[str, str]:
                 ):
                     consumed[i + len(name_tokens)] = True
                 break
-        if 'Church' in participant_data:
+        if "Church" in participant_data:
             break
 
     # --- Pass 2: Match "keyword + value" pattern for churches (e.g., "церковь Грейс") ---
     # This runs only if we haven't already found a church
     church_identifiers = {kw.lower() for kw in CHURCH_KEYWORDS}
-    if 'Church' not in participant_data:
+    if "Church" not in participant_data:
         for i in range(len(tokens) - 1):
-            if not consumed[i] and not consumed[i + 1] and tokens[i].lower() in church_identifiers:
-                participant_data['Church'] = tokens[i + 1].capitalize()
+            if (
+                not consumed[i]
+                and not consumed[i + 1]
+                and tokens[i].lower() in church_identifiers
+            ):
+                participant_data["Church"] = tokens[i + 1].capitalize()
                 consumed[i] = True  # Consume the identifier (e.g., "церковь")
                 consumed[i + 1] = True  # Consume the name
                 break
 
     # --- Pass 2.5: Match "keyword + value" for cities (e.g., "город Хайфа") ---
     city_identifiers = {"город", "из", "city", "from"}
-    if 'CountryAndCity' not in participant_data:
+    if "CountryAndCity" not in participant_data:
         for i in range(len(tokens) - 1):
             if (
                 not consumed[i]
                 and not consumed[i + 1]
                 and tokens[i].lower() in city_identifiers
             ):
-                participant_data['CountryAndCity'] = tokens[i + 1].capitalize()
+                participant_data["CountryAndCity"] = tokens[i + 1].capitalize()
                 consumed[i] = True
                 consumed[i + 1] = True
                 break
 
     # --- Pass 3: Match all other single-token fields ---
     recognizers = {
-        'Role': recognize_role,
-        'Gender': recognize_gender,
-        'Size': recognize_size,
-        'Department': recognize_department,
-        'CountryAndCity': recognize_city,
-        'Church': recognize_church,  # Fallback for single-word church names without identifier
+        "Role": recognize_role,
+        "Gender": recognize_gender,
+        "Size": recognize_size,
+        "Department": recognize_department,
+        "CountryAndCity": recognize_city,
+        "Church": recognize_church,  # Fallback for single-word church names without identifier
     }
     for i, token in enumerate(tokens):
         if consumed[i]:
@@ -251,74 +250,82 @@ def parse_unstructured_text(text: str) -> Dict[str, str]:
     # --- Pass 4: Everything that is left is the name ---
     name_parts = [tokens[i] for i in range(len(tokens)) if not consumed[i]]
     if name_parts:
-        participant_data['FullNameRU'] = " ".join(name_parts)
+        participant_data["FullNameRU"] = " ".join(name_parts)
 
     return participant_data
 
 
 def contains_hebrew(text: str) -> bool:
-    return any('\u0590' <= char <= '\u05FF' for char in text)
+    return any("\u0590" <= char <= "\u05ff" for char in text)
 
 
 def contains_emoji(text: str) -> bool:
     """Проверяет наличие эмодзи"""
     return any(
-        '\U0001F600' <= char <= '\U0001F64F' or  # Emoticons
-        '\U0001F300' <= char <= '\U0001F5FF' or  # Misc Symbols
-        '\U0001F680' <= char <= '\U0001F6FF' or  # Transport & Map
-        '\U0001F1E0' <= char <= '\U0001F1FF' or  # Regional
-        '\U00002600' <= char <= '\U000027BF' or  # Misc
-        '\U0001F900' <= char <= '\U0001F9FF'
+        "\U0001f600" <= char <= "\U0001f64f"  # Emoticons
+        or "\U0001f300" <= char <= "\U0001f5ff"  # Misc Symbols
+        or "\U0001f680" <= char <= "\U0001f6ff"  # Transport & Map
+        or "\U0001f1e0" <= char <= "\U0001f1ff"  # Regional
+        or "\U00002600" <= char <= "\U000027bf"  # Misc
+        or "\U0001f900" <= char <= "\U0001f9ff"
         for char in text
     )
 
 
 def clean_text_from_confirmation_block(text: str) -> str:
     """Удаляет эмодзи и служебные слова из текста подтверждения"""
-    cleaned = ''.join(ch for ch in text if not contains_emoji(ch))
-    cleaned = cleaned.replace('**', '').replace('*', '')
-    cleaned = cleaned.replace('🔍', '').replace('•', '')
+    cleaned = "".join(ch for ch in text if not contains_emoji(ch))
+    cleaned = cleaned.replace("**", "").replace("*", "")
+    cleaned = cleaned.replace("🔍", "").replace("•", "")
 
     field_labels = [
-        'Имя (рус)', 'Имя (англ)', 'Пол', 'Размер', 'Церковь',
-        'Роль', 'Департамент', 'Город', 'Кто подал', 'Контакты'
+        "Имя (рус)",
+        "Имя (англ)",
+        "Пол",
+        "Размер",
+        "Церковь",
+        "Роль",
+        "Департамент",
+        "Город",
+        "Кто подал",
+        "Контакты",
     ]
 
     for label in field_labels:
-        cleaned = re.sub(fr'{label}\s*:', '', cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(rf"{label}\s*:", "", cleaned, flags=re.IGNORECASE)
 
-    cleaned = cleaned.replace(':', '')
+    cleaned = cleaned.replace(":", "")
 
     words = cleaned.split()
     filtered = []
     for word in words:
-        w = word.strip('.,!?:;').upper()
+        w = word.strip(".,!?:;").upper()
         if (
-            w not in CONFIRMATION_NOISE_WORDS and
-            not w.startswith('➖') and
-            not w.startswith('❌') and
-            len(w) > 0
+            w not in CONFIRMATION_NOISE_WORDS
+            and not w.startswith("➖")
+            and not w.startswith("❌")
+            and len(w) > 0
         ):
             filtered.append(word)
 
-    return ' '.join(filtered)
+    return " ".join(filtered)
 
 
 def detect_field_update_intent(text: str) -> Optional[str]:
     """Определяет, какое поле хочет обновить пользователь"""
     text_upper = text.upper()
-    words = re.split(r'\s+', text_upper)
+    words = re.split(r"\s+", text_upper)
 
     for field, indicators in FIELD_INDICATORS.items():
         for ind in indicators:
             if ind in words:
                 return field
 
-    if any(word in GENDER_KEYWORDS['F'] + GENDER_KEYWORDS['M'] for word in words):
-        return 'Gender'
+    if any(word in GENDER_SYNONYMS for word in words):
+        return "Gender"
 
-    if any(word in SIZES for word in words):
-        return 'Size'
+    if any(word in SIZE_SYNONYMS for word in words):
+        return "Size"
 
     return None
 
@@ -329,48 +336,49 @@ def parse_field_update(text: str, field_hint: str) -> Dict:
     words = text_clean.split()
     update: Dict = {}
 
-    if field_hint == 'Gender':
+    if field_hint == "Gender":
         for word in words:
-            gender_val = _norm_gender(word)
+            gender_val = normalize_gender(word)
             if gender_val:
-                update['Gender'] = gender_val
+                update["Gender"] = gender_val
                 break
 
-    elif field_hint == 'Size':
+    elif field_hint == "Size":
         for word in words:
-            size_val = _norm_size(word)
+            size_val = normalize_size(word)
             if size_val:
-                update['Size'] = size_val
+                update["Size"] = size_val
                 break
 
-    elif field_hint == 'Role':
+    elif field_hint == "Role":
         for word in words:
-            role_val = _norm_role(word)
+            role_val = normalize_role(word)
             if role_val:
-                update['Role'] = role_val
+                update["Role"] = role_val
                 break
 
-    elif field_hint == 'Department':
-        dept_keywords = cache.get("departments") or {}
+    elif field_hint == "Department":
         for word in words:
-            dept_val = _norm_department(word, dept_keywords)
+            dept_val = normalize_department(word)
             if dept_val:
-                update['Department'] = dept_val
+                update["Department"] = dept_val
                 break
 
-    elif field_hint == 'Church':
+    elif field_hint == "Church":
         church_words = []
         for word in words:
-            if not any(kw in word.upper() for kw in CHURCH_KEYWORDS) and not contains_hebrew(word):
+            if not any(
+                kw in word.upper() for kw in CHURCH_KEYWORDS
+            ) and not contains_hebrew(word):
                 church_words.append(word)
         if church_words:
-            update['Church'] = ' '.join(church_words)
+            update["Church"] = " ".join(church_words)
 
-    elif field_hint == 'CountryAndCity':
+    elif field_hint == "CountryAndCity":
         cities = cache.get("cities") or []
         for word in words:
             if word.upper() in cities:
-                update['CountryAndCity'] = word
+                update["CountryAndCity"] = word
                 break
 
     return update
@@ -382,6 +390,14 @@ class ParticipantParser:
         self.processed_words: set[str] = set()
         self.department_keywords = cache.get("departments") or {}
         self.israel_cities = cache.get("cities") or []
+        # Cache synonym sets for performance
+        self._size_synonyms = SIZE_SYNONYMS
+        self._role_synonyms = ROLE_SYNONYMS
+        self._dept_synonyms = {
+            syn.upper()
+            for synonyms in self.department_keywords.values()
+            for syn in synonyms
+        }
 
     def parse(self, text: str, is_update: bool = False) -> Dict:
         """Основной метод парсинга."""
@@ -391,16 +407,16 @@ class ParticipantParser:
 
         all_words = text.split()
         self.data = {
-            'FullNameRU': '',
-            'Gender': 'F',
-            'Size': '',
-            'Church': '',
-            'Role': 'CANDIDATE',
-            'Department': '',
-            'FullNameEN': '',
-            'SubmittedBy': '',
-            'ContactInformation': '',
-            'CountryAndCity': ''
+            "FullNameRU": "",
+            "Gender": "F",
+            "Size": "",
+            "Church": "",
+            "Role": "CANDIDATE",
+            "Department": "",
+            "FullNameEN": "",
+            "SubmittedBy": "",
+            "ContactInformation": "",
+            "CountryAndCity": "",
         }
         self.processed_words = set()
 
@@ -410,7 +426,9 @@ class ParticipantParser:
         logger.debug("ParticipantParser result: %s", self.data)
         return self.data
 
-    def _preprocess_text(self, text: str, is_update: bool) -> tuple[str, Optional[Dict]]:
+    def _preprocess_text(
+        self, text: str, is_update: bool
+    ) -> tuple[str, Optional[Dict]]:
         text = text.strip()
         if is_template_format(text):
             logger.debug("Parsing using template format")
@@ -441,7 +459,7 @@ class ParticipantParser:
 
     def _extract_submitted_by(self, text: str):
         """Извлекает информацию о том, кто подал заявку."""
-        match = re.search(r'от\s+([А-ЯЁA-Z][А-Яа-яёA-Za-z\s]+)', text, re.IGNORECASE)
+        match = re.search(r"от\s+([А-ЯЁA-Z][А-Яа-яёA-Za-z\s]+)", text, re.IGNORECASE)
         if match:
             full_match = match.group(1).strip()
             words = full_match.split()
@@ -451,41 +469,44 @@ class ParticipantParser:
                 if word not in self.processed_words:
                     word_upper = word.upper()
                     if (
-                        word_upper not in SIZES and
-                        word_upper not in [k for keys in ROLE_KEYWORDS.values() for k in keys] and
-                        word_upper not in [k for keys in self.department_keywords.values() for k in keys]
+                        word_upper not in self._size_synonyms
+                        and word_upper not in self._role_synonyms
+                        and word_upper not in self._dept_synonyms
                     ):
                         valid_words.append(word)
                     else:
                         break
 
             if valid_words:
-                self.data['SubmittedBy'] = ' '.join(valid_words)
+                self.data["SubmittedBy"] = " ".join(valid_words)
                 for word in valid_words:
                     self.processed_words.add(word)
-                self.processed_words.add('от')
+                self.processed_words.add("от")
 
     def _extract_contacts(self, all_words: list[str]):
         for word in all_words:
             if word in self.processed_words:
                 continue
 
-            if '@' in word and '.' in word.split('@')[-1]:
+            if "@" in word and "." in word.split("@")[-1]:
                 if len(word) >= 5:
-                    self.data['ContactInformation'] = word
+                    self.data["ContactInformation"] = word
                     self.processed_words.add(word)
                     break
 
-            cleaned_phone = ''.join(c for c in word if c.isdigit() or c == '+')
+            cleaned_phone = "".join(c for c in word if c.isdigit() or c == "+")
             digit_count = sum(1 for c in cleaned_phone if c.isdigit())
 
             if digit_count >= 7:
                 if (
-                    word.startswith(('+', '8', '7')) or
-                    digit_count >= 10 or
-                    (digit_count >= 7 and any(char in word for char in ['-', '(', ')', ' ']))
+                    word.startswith(("+", "8", "7"))
+                    or digit_count >= 10
+                    or (
+                        digit_count >= 7
+                        and any(char in word for char in ["-", "(", ")", " "])
+                    )
                 ):
-                    self.data['ContactInformation'] = word
+                    self.data["ContactInformation"] = word
                     self.processed_words.add(word)
                     break
 
@@ -495,9 +516,9 @@ class ParticipantParser:
         for word in all_words:
             if word in self.processed_words:
                 continue
-            wu = _norm_token(word)
-            if wu in GENDER_KEYWORDS['F']:
-                self.data['Gender'] = 'F'
+            wu = word.strip(PUNCTUATION_CHARS).upper()
+            if wu in field_normalizer.GENDER_MAPPINGS["F"]:
+                self.data["Gender"] = "F"
                 gender_explicit = True
                 self.processed_words.add(word)
                 return
@@ -505,22 +526,22 @@ class ParticipantParser:
         for idx, word in enumerate(all_words):
             if word in self.processed_words:
                 continue
-            wu = _norm_token(word)
+            wu = word.strip(PUNCTUATION_CHARS).upper()
 
-            if wu in GENDER_KEYWORDS['M'] and not gender_explicit:
-                if wu == 'M' and not self.data.get('Size'):
+            if wu in field_normalizer.GENDER_MAPPINGS["M"] and not gender_explicit:
+                if wu == "M" and not self.data.get("Size"):
                     ctx = []
                     if idx > 0:
                         ctx.append(all_words[idx - 1].upper())
                     if idx < len(all_words) - 1:
                         ctx.append(all_words[idx + 1].upper())
 
-                    if any('РАЗМЕР' in c or 'SIZE' in c for c in ctx):
-                        self.data['Size'] = 'M'
+                    if any("РАЗМЕР" in c or "SIZE" in c for c in ctx):
+                        self.data["Size"] = "M"
                     else:
-                        self.data['Gender'] = 'M'
+                        self.data["Gender"] = "M"
                 else:
-                    self.data['Gender'] = 'M'
+                    self.data["Gender"] = "M"
                 self.processed_words.add(word)
                 break
 
@@ -528,39 +549,32 @@ class ParticipantParser:
         for word in all_words:
             if word in self.processed_words:
                 continue
-            wu = _norm_token(word)
-            if wu in NORMALIZED_SIZES:
-                size_val = _norm_size(word)
-                if size_val:
-                    self.data['Size'] = size_val
-                    self.processed_words.add(word)
+            size_val = normalize_size(word)
+            if size_val:
+                self.data["Size"] = size_val
+                self.processed_words.add(word)
 
     def _extract_role_and_department(self, all_words: list[str]):
         for word in all_words:
             if word in self.processed_words:
                 continue
-            wu = _norm_token(word)
-
-            if any(keyword == wu for keyword in ROLE_KEYWORDS['TEAM']):
-                self.data['Role'] = 'TEAM'
-                self.processed_words.add(word)
-            elif any(keyword == wu for keyword in ROLE_KEYWORDS['CANDIDATE']):
-                self.data['Role'] = 'CANDIDATE'
+            role_val = normalize_role(word)
+            if role_val:
+                self.data["Role"] = role_val
                 self.processed_words.add(word)
             elif not contains_hebrew(word):
-                for dept, keywords in self.department_keywords.items():
-                    if any(_norm_token(keyword) == wu for keyword in keywords):
-                        self.data['Department'] = dept
-                        self.processed_words.add(word)
-                        break
+                dept_val = normalize_department(word)
+                if dept_val:
+                    self.data["Department"] = dept_val
+                    self.processed_words.add(word)
 
     def _extract_city(self, all_words: list[str]):
         for word in all_words:
             if word in self.processed_words or contains_hebrew(word):
                 continue
-            wu = _norm_token(word)
+            wu = word.strip(PUNCTUATION_CHARS).upper()
             if wu in self.israel_cities:
-                self.data['CountryAndCity'] = word
+                self.data["CountryAndCity"] = word
                 self.processed_words.add(word)
 
     def _extract_church(self, all_words: list[str]):
@@ -571,22 +585,22 @@ class ParticipantParser:
             if any(keyword in word_upper for keyword in CHURCH_KEYWORDS):
                 church_words = []
                 if (
-                    i > 0 and
-                    all_words[i - 1] not in self.processed_words and
-                    not contains_hebrew(all_words[i - 1])
+                    i > 0
+                    and all_words[i - 1] not in self.processed_words
+                    and not contains_hebrew(all_words[i - 1])
                 ):
                     church_words.append(all_words[i - 1])
                     self.processed_words.add(all_words[i - 1])
                 church_words.append(word)
                 self.processed_words.add(word)
                 if (
-                    i < len(all_words) - 1 and
-                    all_words[i + 1] not in self.processed_words and
-                    not contains_hebrew(all_words[i + 1])
+                    i < len(all_words) - 1
+                    and all_words[i + 1] not in self.processed_words
+                    and not contains_hebrew(all_words[i + 1])
                 ):
                     church_words.append(all_words[i + 1])
                     self.processed_words.add(all_words[i + 1])
-                self.data['Church'] = ' '.join(church_words)
+                self.data["Church"] = " ".join(church_words)
                 break
 
     def _extract_names(self, all_words: list[str]):
@@ -599,9 +613,9 @@ class ParticipantParser:
             else:
                 russian_words.append(word)
         if russian_words:
-            self.data['FullNameRU'] = ' '.join(russian_words[:2])
+            self.data["FullNameRU"] = " ".join(russian_words[:2])
         if english_words:
-            self.data['FullNameEN'] = ' '.join(english_words[:2])
+            self.data["FullNameEN"] = " ".join(english_words[:2])
 
 
 def parse_participant_data(text: str, is_update: bool = False) -> Dict:
@@ -614,18 +628,16 @@ def normalize_field_value(field_name: str, value: str) -> str:
     """Нормализует одно значение для указанного поля."""
     value = value.strip()
 
-    if field_name == 'Department':
-        dept_keywords = cache.get("departments") or {}
-        return _norm_department(value, dept_keywords) or ''
+    if field_name == "Department":
+        return normalize_department(value) or ""
 
-    if field_name == 'Gender':
-        return _norm_gender(value) or ''
+    if field_name == "Gender":
+        return normalize_gender(value) or ""
 
-    if field_name == 'Size':
-        return _norm_size(value) or ''
+    if field_name == "Size":
+        return normalize_size(value) or ""
 
-    if field_name == 'Role':
-        return _norm_role(value) or 'CANDIDATE'
+    if field_name == "Role":
+        return normalize_role(value) or "CANDIDATE"
 
     return value
-

--- a/tests/test_field_normalizer.py
+++ b/tests/test_field_normalizer.py
@@ -1,0 +1,100 @@
+import unittest
+from utils.field_normalizer import (
+    field_normalizer,
+    normalize_gender,
+    normalize_role,
+    normalize_size,
+    normalize_department,
+)
+
+
+class FieldNormalizerTestCase(unittest.TestCase):
+    def test_gender_normalization(self):
+        """Тестирует нормализацию пола"""
+        # Мужской пол
+        self.assertEqual(normalize_gender('M'), 'M')
+        self.assertEqual(normalize_gender('муж'), 'M')
+        self.assertEqual(normalize_gender('мужской'), 'M')
+        self.assertEqual(normalize_gender('male'), 'M')
+
+        # Женский пол
+        self.assertEqual(normalize_gender('F'), 'F')
+        self.assertEqual(normalize_gender('жен'), 'F')
+        self.assertEqual(normalize_gender('женский'), 'F')
+        self.assertEqual(normalize_gender('female'), 'F')
+
+        # Неизвестные значения
+        self.assertIsNone(normalize_gender('неизвестно'))
+        self.assertIsNone(normalize_gender(''))
+
+    def test_role_normalization(self):
+        """Тестирует нормализацию ролей"""
+        # Team роли
+        self.assertEqual(normalize_role('team'), 'TEAM')
+        self.assertEqual(normalize_role('команда'), 'TEAM')
+        self.assertEqual(normalize_role('тим'), 'TEAM')
+        self.assertEqual(normalize_role('служитель'), 'TEAM')
+
+        # Candidate роли
+        self.assertEqual(normalize_role('candidate'), 'CANDIDATE')
+        self.assertEqual(normalize_role('кандидат'), 'CANDIDATE')
+        self.assertEqual(normalize_role('участник'), 'CANDIDATE')
+
+        # Неизвестные значения
+        self.assertIsNone(normalize_role('неизвестно'))
+
+    def test_size_normalization(self):
+        """Тестирует нормализацию размеров"""
+        self.assertEqual(normalize_size('M'), 'M')
+        self.assertEqual(normalize_size('medium'), 'M')
+        self.assertEqual(normalize_size('медиум'), 'M')
+
+        self.assertEqual(normalize_size('L'), 'L')
+        self.assertEqual(normalize_size('large'), 'L')
+
+        self.assertEqual(normalize_size('XL'), 'XL')
+        self.assertEqual(normalize_size('extra large'), 'XL')
+
+        # Неизвестные размеры
+        self.assertIsNone(normalize_size('огромный'))
+
+    def test_department_normalization(self):
+        """Тестирует нормализацию департаментов"""
+        self.assertEqual(normalize_department('админ'), 'Administration')
+        self.assertEqual(normalize_department('admin'), 'Administration')
+        self.assertEqual(normalize_department('администрация'), 'Administration')
+
+        self.assertEqual(normalize_department('worship'), 'Worship')
+        self.assertEqual(normalize_department('воршип'), 'Worship')
+        self.assertEqual(normalize_department('прославление'), 'Worship')
+
+        self.assertEqual(normalize_department('кухня'), 'Kitchen')
+        self.assertEqual(normalize_department('kitchen'), 'Kitchen')
+
+        # Неизвестные департаменты
+        self.assertIsNone(normalize_department('неизвестный'))
+
+    def test_confidence_scoring(self):
+        """Тестирует scoring уверенности"""
+        result = field_normalizer.normalize_gender('мужской')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.normalized_value, 'M')
+        self.assertEqual(result.confidence, 1.0)
+        self.assertTrue(result.is_confident)
+
+    def test_case_insensitive(self):
+        """Тестирует нечувствительность к регистру"""
+        self.assertEqual(normalize_gender('МУЖ'), 'M')
+        self.assertEqual(normalize_gender('муж'), 'M')
+        self.assertEqual(normalize_gender('Муж'), 'M')
+        self.assertEqual(normalize_gender('МуЖ'), 'M')
+
+    def test_whitespace_handling(self):
+        """Тестирует обработку пробелов"""
+        self.assertEqual(normalize_gender(' муж '), 'M')
+        self.assertEqual(normalize_size(' medium '), 'M')
+        self.assertEqual(normalize_role(' команда '), 'TEAM')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_normalize_field_value.py
+++ b/tests/test_normalize_field_value.py
@@ -1,8 +1,7 @@
 import unittest
 from parsers.participant_parser import normalize_field_value
-from utils.cache import load_reference_data
 
-load_reference_data()
+# Нормализатор инициализируется автоматически, не нужно загружать кэш
 
 class NormalizeFieldValueTestCase(unittest.TestCase):
     def test_unknown_department(self):

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -11,13 +11,16 @@ class SimpleCache:
     def clear(self):
         self._cache.clear()
 
+
 cache = SimpleCache()
 
 
 def load_reference_data():
     """Load cities and departments into cache."""
-    from constants import DEPARTMENT_KEYWORDS, ISRAEL_CITIES
+    from constants import ISRAEL_CITIES
+    from utils.field_normalizer import field_normalizer
 
-    cache.set("departments", DEPARTMENT_KEYWORDS)
+    # Теперь департаменты берем из нормализатора
+    cache.set("departments", field_normalizer.DEPARTMENT_MAPPINGS)
     cache.set("cities", ISRAEL_CITIES)
-
+    cache.set("churches", [])  # Можно добавить известные церкви

--- a/utils/field_normalizer.py
+++ b/utils/field_normalizer.py
@@ -1,0 +1,326 @@
+"""Field normalization utilities for participant data."""
+
+from typing import Optional, Set
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FieldType(Enum):
+    GENDER = "gender"
+    ROLE = "role"
+    SIZE = "size"
+    DEPARTMENT = "department"
+
+
+@dataclass
+class NormalizationResult:
+    """Result of field normalization with confidence."""
+
+    field_type: FieldType
+    original_value: str
+    normalized_value: str
+    confidence: float
+
+    @property
+    def is_confident(self) -> bool:
+        return self.confidence >= 0.8
+
+
+class FieldNormalizer:
+    """Unified normalizer for participant fields."""
+
+    def __init__(self) -> None:
+        self._init_mappings()
+
+    def _init_mappings(self) -> None:
+        """Initialize mapping dictionaries."""
+
+        # === GENDER MAPPINGS ===
+        self.GENDER_MAPPINGS = {
+            "M": {"M", "МУЖ", "МУЖСКОЙ", "MALE", "М", "МУЖЧИНА", "МУЖЕ", "МУЖИК"},
+            "F": {
+                "F",
+                "ЖЕН",
+                "ЖЕНСКИЙ",
+                "FEMALE",
+                "Ж",
+                "ЖЕНЩИНА",
+                "ЖЕНА",
+                "ДЕВОЧКА",
+            },
+        }
+
+        # === ROLE MAPPINGS ===
+        self.ROLE_MAPPINGS = {
+            "TEAM": {
+                "TEAM",
+                "КОМАНДА",
+                "ТИМ",
+                "TIM",
+                "TEAM MEMBER",
+                "ЧЛЕН КОМАНДЫ",
+                "КОМАНДНЫЙ",
+                "СЛУЖИТЕЛЬ",
+                "СЛУЖЕНИЕ",
+                "STAFF",
+            },
+            "CANDIDATE": {
+                "CANDIDATE",
+                "КАНДИДАТ",
+                "УЧАСТНИК",
+                "КАНДИДАТКА",
+                "CANDIDAT",
+                "УЧАСТНИЦА",
+                "ПАЛОМНИК",
+                "ПАЛОМНИЦА",
+            },
+        }
+
+        # === SIZE MAPPINGS ===
+        self.SIZE_MAPPINGS = {
+            "XS": {"XS", "EXTRA SMALL", "EXTRASMALL", "ХС"},
+            "S": {"S", "SMALL", "СМОЛ", "С"},
+            "M": {"M", "MEDIUM", "МЕДИУМ", "СРЕДНИЙ", "СРЕДНЯЯ"},
+            "L": {"L", "LARGE", "ЛАРЖ"},
+            "XL": {"XL", "EXTRA LARGE", "EXTRALARGE", "ХЛ"},
+            "XXL": {"XXL", "2XL", "EXTRA EXTRA LARGE", "ХХЛ"},
+            "3XL": {"3XL", "XXXL", "ХХХЛ"},
+        }
+
+        # === DEPARTMENT MAPPINGS ===
+        self.DEPARTMENT_MAPPINGS = {
+            "ROE": {"ROE", "РОЕ", "ROE ROOM", "РОЕ РУМ", "РОЭ", "РОИ"},
+            "Chapel": {
+                "CHAPEL",
+                "МОЛИТВЕННЫЙ",
+                "МОЛИТВА",
+                "PRAYER",
+                "ЧАСОВНЯ",
+                "ЧАПЕЛ",
+            },
+            "Setup": {"SETUP", "СЕТАП", "НАСТРОЙКА", "ПОДГОТОВКА", "СЕТ АП", "СЕТАП"},
+            "Palanka": {"PALANKA", "ПАЛАНКА", "ПОЛАНКА"},
+            "Administration": {
+                "ADMINISTRATION",
+                "АДМИНИСТРАЦИЯ",
+                "АДМИН",
+                "ADMIN",
+                "УПРАВЛЕНИЕ",
+                "АДМИНИСТРАТИВНЫЙ",
+                "ОФИС",
+            },
+            "Kitchen": {
+                "KITCHEN",
+                "КУХНЯ",
+                "КИТЧЕН",
+                "КУЛИНАРИЯ",
+                "ПОВАРА",
+                "ЕДА",
+                "ПИТАНИЕ",
+            },
+            "Decoration": {
+                "DECORATION",
+                "ДЕКОРАЦИИ",
+                "ДЕКОР",
+                "DECO",
+                "DECOR",
+                "УКРАШЕНИЕ",
+                "ОФОРМЛЕНИЕ",
+                "ДЕКОРАТОР",
+            },
+            "Bell": {
+                "BELL",
+                "ЗВОНАРЬ",
+                "БЕЛЛ",
+                "ЗВОН",
+                "КОЛОКОЛЬЧИК",
+                "ЗВОНОК",
+            },
+            "Refreshment": {
+                "REFRESHMENT",
+                "РЕФРЕШМЕНТ",
+                "УГОЩЕНИЯ",
+                "НАПИТКИ",
+                "ОСВЕЖЕНИЕ",
+            },
+            "Worship": {
+                "WORSHIP",
+                "ПРОСЛАВЛЕНИЕ",
+                "ВОРШИП",
+                "МУЗЫКА",
+                "MUSIC",
+                "ПЕСНИ",
+                "ХВАЛА",
+                "ПРОСЛАВИТЕЛЬ",
+            },
+            "Media": {
+                "MEDIA",
+                "МЕДИА",
+                "ВИДЕО",
+                "ФОТО",
+                "СЪЕМКА",
+                "КАМЕРА",
+                "ФОТОГРАФ",
+                "ВИДЕОГРАФ",
+                "ТЕХНИКА",
+            },
+            "Духовенство": {
+                "ДУХОВЕНСТВО",
+                "CLERGY",
+                "СВЯЩЕННИКИ",
+                "СВЯЩЕННИК",
+                "ПАСТОР",
+            },
+            "Ректорат": {"РЕКТОРАТ", "RECTOR", "РЕКТОРЫ", "РЕКТОР"},
+        }
+
+        self._create_reverse_indexes()
+
+    def _create_reverse_indexes(self) -> None:
+        """Create reverse indexes for fast lookup."""
+
+        self._gender_index: dict[str, str] = {}
+        self._role_index: dict[str, str] = {}
+        self._size_index: dict[str, str] = {}
+        self._department_index: dict[str, str] = {}
+
+        for canonical, synonyms in self.GENDER_MAPPINGS.items():
+            for synonym in synonyms:
+                self._gender_index[synonym.upper()] = canonical
+
+        for canonical, synonyms in self.ROLE_MAPPINGS.items():
+            for synonym in synonyms:
+                self._role_index[synonym.upper()] = canonical
+
+        for canonical, synonyms in self.SIZE_MAPPINGS.items():
+            for synonym in synonyms:
+                self._size_index[synonym.upper()] = canonical
+
+        for canonical, synonyms in self.DEPARTMENT_MAPPINGS.items():
+            for synonym in synonyms:
+                self._department_index[synonym.upper()] = canonical
+
+    def normalize_gender(self, value: str) -> Optional[NormalizationResult]:
+        """Normalize participant gender."""
+        if not value or not value.strip():
+            return None
+
+        clean_value = value.strip().upper()
+        canonical = self._gender_index.get(clean_value)
+
+        if canonical:
+            return NormalizationResult(
+                field_type=FieldType.GENDER,
+                original_value=value,
+                normalized_value=canonical,
+                confidence=1.0,
+            )
+        return None
+
+    def normalize_role(self, value: str) -> Optional[NormalizationResult]:
+        """Normalize participant role."""
+        if not value or not value.strip():
+            return None
+
+        clean_value = value.strip().upper()
+        canonical = self._role_index.get(clean_value)
+
+        if canonical:
+            return NormalizationResult(
+                field_type=FieldType.ROLE,
+                original_value=value,
+                normalized_value=canonical,
+                confidence=1.0,
+            )
+        return None
+
+    def normalize_size(self, value: str) -> Optional[NormalizationResult]:
+        """Normalize clothing size."""
+        if not value or not value.strip():
+            return None
+
+        clean_value = value.strip().upper()
+        canonical = self._size_index.get(clean_value)
+
+        if canonical:
+            return NormalizationResult(
+                field_type=FieldType.SIZE,
+                original_value=value,
+                normalized_value=canonical,
+                confidence=1.0,
+            )
+        return None
+
+    def normalize_department(self, value: str) -> Optional[NormalizationResult]:
+        """Normalize department name."""
+        if not value or not value.strip():
+            return None
+
+        clean_value = value.strip().upper()
+        canonical = self._department_index.get(clean_value)
+
+        if canonical:
+            return NormalizationResult(
+                field_type=FieldType.DEPARTMENT,
+                original_value=value,
+                normalized_value=canonical,
+                confidence=1.0,
+            )
+        return None
+
+    def normalize_field(
+        self, field_type: FieldType, value: str
+    ) -> Optional[NormalizationResult]:
+        """Generic normalization by field type."""
+        if field_type == FieldType.GENDER:
+            return self.normalize_gender(value)
+        if field_type == FieldType.ROLE:
+            return self.normalize_role(value)
+        if field_type == FieldType.SIZE:
+            return self.normalize_size(value)
+        if field_type == FieldType.DEPARTMENT:
+            return self.normalize_department(value)
+        return None
+
+    def get_gender_options(self) -> Set[str]:
+        """Return all canonical gender values."""
+        return set(self.GENDER_MAPPINGS.keys())
+
+    def get_role_options(self) -> Set[str]:
+        """Return all canonical role values."""
+        return set(self.ROLE_MAPPINGS.keys())
+
+    def get_size_options(self) -> Set[str]:
+        """Return all canonical size values."""
+        return set(self.SIZE_MAPPINGS.keys())
+
+    def get_department_options(self) -> Set[str]:
+        """Return all canonical departments."""
+        return set(self.DEPARTMENT_MAPPINGS.keys())
+
+
+field_normalizer = FieldNormalizer()
+
+
+def normalize_gender(value: str) -> Optional[str]:
+    """Convenience function for gender normalization."""
+    result = field_normalizer.normalize_gender(value)
+    return result.normalized_value if result else None
+
+
+def normalize_role(value: str) -> Optional[str]:
+    """Convenience function for role normalization."""
+    result = field_normalizer.normalize_role(value)
+    return result.normalized_value if result else None
+
+
+def normalize_size(value: str) -> Optional[str]:
+    """Convenience function for size normalization."""
+    result = field_normalizer.normalize_size(value)
+    return result.normalized_value if result else None
+
+
+def normalize_department(value: str) -> Optional[str]:
+    """Convenience function for department normalization."""
+    result = field_normalizer.normalize_department(value)
+    return result.normalized_value if result else None

--- a/utils/recognizers.py
+++ b/utils/recognizers.py
@@ -1,26 +1,11 @@
 from typing import Optional
 from utils.cache import cache
-
-ROLE_MAP = {
-    'тим': 'TEAM', 'команда': 'TEAM', 'team': 'TEAM',
-    'участник': 'Participant', 'кандидат': 'Participant', 'participant': 'Participant'
-}
-
-GENDER_MAP = {
-    'м': 'M', 'm': 'M', 'муж': 'M', 'мужской': 'M',
-    'ж': 'F', 'f': 'F', 'жен': 'F', 'женский': 'F'
-}
-
-SIZE_MAP = {
-    'xs': 'XS', 's': 'S', 'm': 'M', 'l': 'L', 'xl': 'XL', 'xxl': 'XXL',
-    'хс': 'XS', 'с': 'S', 'м': 'M', 'л': 'L', 'хл': 'XL', 'ххл': 'XXL'
-}
-
-DEPARTMENT_MAP = {
-    'админ': 'Administration', 'администрация': 'Administration',
-    'кухня': 'Kitchen',
-    'прославление': 'Worship', 'воршип': 'Worship',
-}
+from utils.field_normalizer import (
+    normalize_gender,
+    normalize_role,
+    normalize_size,
+    normalize_department,
+)
 
 
 def get_reference_data(key: str):
@@ -28,28 +13,30 @@ def get_reference_data(key: str):
 
 
 def recognize_role(token: str) -> Optional[str]:
-    return ROLE_MAP.get(token.lower())
+    """Распознает роль из токена"""
+    return normalize_role(token)
 
 
 def recognize_gender(token: str) -> Optional[str]:
-    return GENDER_MAP.get(token.lower())
+    """Распознает пол из токена"""
+    return normalize_gender(token)
 
 
 def recognize_size(token: str) -> Optional[str]:
-    return SIZE_MAP.get(token.lower())
+    """Распознает размер из токена"""
+    return normalize_size(token)
 
 
 def recognize_department(token: str) -> Optional[str]:
-    for alias, standard in DEPARTMENT_MAP.items():
-        if alias in token.lower():
-            return standard
-    return None
+    """Распознает департамент из токена"""
+    return normalize_department(token)
 
 
 def recognize_church(token: str) -> Optional[str]:
+    """Распознает церковь из токена"""
     if len(token) < 3:
         return None
-    churches = get_reference_data('churches')
+    churches = get_reference_data("churches")
     for church_name in churches:
         if token.lower() in church_name.lower():
             return church_name
@@ -57,10 +44,12 @@ def recognize_church(token: str) -> Optional[str]:
 
 
 def recognize_city(token: str) -> Optional[str]:
+    """Распознает город из токена"""
     if len(token) < 3:
         return None
-    cities = get_reference_data('cities')
+    cities = get_reference_data("cities")
+    token_upper = token.upper()
     for city_name in cities:
-        if token.lower() in city_name.lower():
+        if token_upper in city_name or city_name in token_upper:
             return city_name
     return None


### PR DESCRIPTION
## Summary
- drop keyword constants from `constants.py`
- load department mappings from `field_normalizer`
- use field normalizer mappings in participant parser
- load an empty list of churches in cache
- add tests for the new field normalizer module
- update normalization test imports
- document the field normalizer module
- remove unused imports
- restore partial city matching logic
- cache synonym sets for performance

## Testing
- `python -m unittest tests.test_field_normalizer -v`
- `python -m unittest tests.test_normalize_field_value -v`
- `python -m unittest tests.test_parser -v`
- `python -m unittest discover tests -v`


------
https://chatgpt.com/codex/tasks/task_e_688b4ede995083249a4f986c65c5be27