### PR TITLE
Fix contact validation

### DIFF
--- a/tests/test_contact_validation.py
+++ b/tests/test_contact_validation.py
@@ -1,0 +1,87 @@
+import unittest
+
+from parsers.participant_parser import is_valid_phone
+from parsers.participant_parser import parse_participant_data
+
+
+class IsraeliPhoneValidationTestCase(unittest.TestCase):
+    def test_valid_israeli_phones(self):
+        """Тест корректных израильских номеров"""
+        valid_phones = [
+            # Мобильные местные
+            "050-123-4567",
+            "052-123-4567",
+            "053-123-4567",
+            "054-123-4567",
+            "055-123-4567",
+            "058-123-4567",
+            "0501234567",
+            # Международные
+            "+972-50-123-4567",
+            "+972-52-123-4567",
+            "+972501234567",
+            "+972521234567",
+            # Стационарные
+            "02-123-4567",
+            "03-123-4567",
+            "04-123-4567",
+            "08-123-4567",
+            "09-123-4567",
+            "+972-2-123-4567",
+            # С различным форматированием
+            "050 123 4567",
+            "050.123.4567",
+            "(050) 123-4567",
+        ]
+
+        for phone in valid_phones:
+            with self.subTest(phone=phone):
+                self.assertTrue(
+                    is_valid_phone(phone), f"Should be valid Israeli phone: {phone}"
+                )
+
+    def test_invalid_israeli_phones(self):
+        """Тест некорректных номеров"""
+        invalid_phones = [
+            "051-123-4567",
+            "056-123-4567",
+            "057-123-4567",
+            "059-123-4567",
+            "050-12-345",
+            "050-123-45678",
+            "01-123-4567",
+            "05-123-4567",
+            "07-123-4567",
+            "+972-51-123-4567",
+            "+972-1-123-4567",
+            "12345",
+            "050123456789012345",
+            "0000000000",
+            "1111111111",
+        ]
+
+        for phone in invalid_phones:
+            with self.subTest(phone=phone):
+                self.assertFalse(is_valid_phone(phone), f"Should be invalid: {phone}")
+
+    def test_israeli_parser_integration(self):
+        """Тест интеграции с парсером для израильских номеров"""
+        result = parse_participant_data("Моше Коэн муж L церковь Грейс 050-123-4567")
+        self.assertEqual(result["ContactInformation"], "050-123-4567")
+
+        result = parse_participant_data(
+            "Сара Леви жен M церковь Шалом +972-52-123-4567"
+        )
+        self.assertEqual(result["ContactInformation"], "+972-52-123-4567")
+
+        result = parse_participant_data(
+            "Авраам Иванов муж XL церковь Благодать 02-123-4567"
+        )
+        self.assertEqual(result["ContactInformation"], "02-123-4567")
+
+        result = parse_participant_data("Ицхак Петров муж L церковь Грейс 051-123-4567")
+        self.assertEqual(result["ContactInformation"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,83 +9,114 @@ from utils.cache import load_reference_data, cache
 
 load_reference_data()
 
+
 class ParserTestCase(unittest.TestCase):
     def test_parse_candidate(self):
         text = "Иван Петров M L церковь Новая Жизнь кандидат"
         data = parse_participant_data(text)
-        self.assertEqual(data['FullNameRU'], 'Иван Петров')
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], 'L')
-        self.assertEqual(data['Role'], 'CANDIDATE')
+        self.assertEqual(data["FullNameRU"], "Иван Петров")
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "L")
+        self.assertEqual(data["Role"], "CANDIDATE")
 
     def test_parse_team_with_department(self):
         text = "Анна Иванова F S церковь Благодать команда worship"
         data = parse_participant_data(text)
-        self.assertEqual(data['Role'], 'TEAM')
-        self.assertEqual(data['Department'], 'Worship')
+        self.assertEqual(data["Role"], "TEAM")
+        self.assertEqual(data["Department"], "Worship")
 
     def test_russian_size_and_gender_priority(self):
         text = "Ольга Сергеевна жен М Афула церковь Благодать"
         data = parse_participant_data(text)
-        self.assertEqual(data['Gender'], 'F')
-        self.assertEqual(data['Size'], '')
-        self.assertEqual(data['CountryAndCity'], 'Афула')
-        self.assertEqual(data['Church'], 'церковь Благодать')
+        self.assertEqual(data["Gender"], "F")
+        self.assertEqual(data["Size"], "")
+        self.assertEqual(data["CountryAndCity"], "Афула")
+        self.assertEqual(data["Church"], "церковь Благодать")
 
     def test_update_gender_only(self):
         text = "Пол женский"
         data = parse_participant_data(text, is_update=True)
-        self.assertEqual(data, {'Gender': 'F'})
+        self.assertEqual(data, {"Gender": "F"})
 
     def test_size_medium_synonym(self):
         text = "размер medium"
         data = parse_participant_data(text, is_update=True)
-        self.assertEqual(data, {'Size': 'M'})
+        self.assertEqual(data, {"Size": "M"})
 
     def test_template_parsing(self):
         text = "Имя (рус): Иван Петров, Пол: M, Размер: L, Церковь: Благодать"
         self.assertTrue(is_template_format(text))
         data = parse_participant_data(text)
-        self.assertEqual(data['FullNameRU'], 'Иван Петров')
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], 'L')
-        self.assertEqual(data['Church'], 'Благодать')
+        self.assertEqual(data["FullNameRU"], "Иван Петров")
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "L")
+        self.assertEqual(data["Church"], "Благодать")
 
     def test_medium_size_not_in_submitted_by(self):
         """Тест проверяет, что 'medium' распознается как размер, а не как часть имени подавшего"""
         text = "Тест Басис тим админ община грейс муж Хайфа от Ирина Цой medium"
         data = parse_participant_data(text)
-        
-        self.assertEqual(data['FullNameRU'], 'Тест Басис')
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], 'M')  # medium должен стать M
-        self.assertEqual(data['Role'], 'TEAM')
-        self.assertEqual(data['Department'], 'Administration')
-        self.assertEqual(data['Church'], 'община грейс')
-        self.assertEqual(data['CountryAndCity'], 'Хайфа')
-        self.assertEqual(data['SubmittedBy'], 'Ирина Цой')  # без 'medium'
+
+        self.assertEqual(data["FullNameRU"], "Тест Басис")
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "M")  # medium должен стать M
+        self.assertEqual(data["Role"], "TEAM")
+        self.assertEqual(data["Department"], "Administration")
+        self.assertEqual(data["Church"], "община грейс")
+        self.assertEqual(data["CountryAndCity"], "Хайфа")
+        self.assertEqual(data["SubmittedBy"], "Ирина Цой")  # без 'medium'
 
     def test_contact_validation(self):
         """Тест проверяет валидацию контактной информации"""
         # Некорректные контакты не должны распознаваться
         text1 = "Иван Петров муж L церковь Грейс кандидат Н"
         data1 = parse_participant_data(text1)
-        self.assertEqual(data1['ContactInformation'], '')  # Н не должно быть контактом
+        self.assertEqual(data1["ContactInformation"], "")  # Н не должно быть контактом
 
         # Корректные телефоны должны распознаваться
         text2 = "Иван Петров муж L церковь Грейс кандидат +972501234567"
         data2 = parse_participant_data(text2)
-        self.assertEqual(data2['ContactInformation'], '+972501234567')
+        self.assertEqual(data2["ContactInformation"], "+972501234567")
+
+        text2b = "Иван Петров муж L церковь Грейс кандидат 050-123-4567"
+        data2b = parse_participant_data(text2b)
+        self.assertEqual(data2b["ContactInformation"], "050-123-4567")
+
+        text2c = "Иван Петров муж L церковь Грейс кандидат 03-123-4567"
+        data2c = parse_participant_data(text2c)
+        self.assertEqual(data2c["ContactInformation"], "03-123-4567")
 
         # Корректные email должны распознаваться
         text3 = "Иван Петров муж L церковь Грейс кандидат ivan@mail.ru"
         data3 = parse_participant_data(text3)
-        self.assertEqual(data3['ContactInformation'], 'ivan@mail.ru')
+        self.assertEqual(data3["ContactInformation"], "ivan@mail.ru")
 
         # Некорректные 'телефоны' не должны распознаваться
         text4 = "Иван Петров муж L церковь Грейс кандидат 123"
         data4 = parse_participant_data(text4)
-        self.assertEqual(data4['ContactInformation'], '')  # 123 слишком короткий
+        self.assertEqual(data4["ContactInformation"], "")  # 123 слишком короткий
+
+        # Некорректные email и телефоны
+        text5 = "Иван Петров муж L церковь Грейс кандидат test@."
+        data5 = parse_participant_data(text5)
+        self.assertEqual(data5["ContactInformation"], "")
+
+        text6 = "Иван Петров муж L церковь Грейс кандидат Петров@abc"
+        data6 = parse_participant_data(text6)
+        self.assertEqual(data6["ContactInformation"], "")
+
+        text7 = "Иван Петров муж L церковь Грейс кандидат 12345678"
+        data7 = parse_participant_data(text7)
+        self.assertEqual(data7["ContactInformation"], "")
+
+        # Контакты с завершающей пунктуацией должны очищаться
+        text8 = "Иван Петров муж L церковь Грейс кандидат ivan@mail.ru,"
+        data8 = parse_participant_data(text8)
+        self.assertEqual(data8["ContactInformation"], "ivan@mail.ru")
+
+        text9 = "Иван Петров муж L церковь Грейс кандидат +972(50)123-45-67,"
+        data9 = parse_participant_data(text9)
+        self.assertEqual(data9["ContactInformation"], "+972(50)123-45-67")
 
     def test_is_template_format_variants(self):
         self.assertTrue(is_template_format("Имя (рус): Иван\nПол: M\nЦерковь: XYZ"))
@@ -94,51 +125,56 @@ class ParserTestCase(unittest.TestCase):
     def test_parse_template_partial(self):
         text = "Имя (рус): Иван Петров\nПол: M\nРазмер:\nЦерковь: Благодать"
         data = parse_template_format(text)
-        self.assertEqual(data['FullNameRU'], 'Иван Петров')
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], '')
-        self.assertEqual(data['Church'], 'Благодать')
+        self.assertEqual(data["FullNameRU"], "Иван Петров")
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "")
+        self.assertEqual(data["Church"], "Благодать")
 
     def test_parse_template_single_line_commas(self):
         text = "Имя (рус): Иван, Пол: M, Размер: L, Церковь: Благодать"
         data = parse_template_format(text)
-        self.assertEqual(data['FullNameRU'], 'Иван')
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], 'L')
-        self.assertEqual(data['Church'], 'Благодать')
+        self.assertEqual(data["FullNameRU"], "Иван")
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "L")
+        self.assertEqual(data["Church"], "Благодать")
 
     def test_template_normalization(self):
-        text = "\n".join([
-            "Имя (рус): Иван Петров",
-            "Пол: муж",
-            "Размер: extra large",
-            "Роль: тим",
-            "Департамент: админ",
-        ])
+        text = "\n".join(
+            [
+                "Имя (рус): Иван Петров",
+                "Пол: муж",
+                "Размер: extra large",
+                "Роль: тим",
+                "Департамент: админ",
+            ]
+        )
         data = parse_participant_data(text)
-        self.assertEqual(data['Gender'], 'M')
-        self.assertEqual(data['Size'], 'XL')
-        self.assertEqual(data['Role'], 'TEAM')
-        self.assertEqual(data['Department'], 'Administration')
+        self.assertEqual(data["Gender"], "M")
+        self.assertEqual(data["Size"], "XL")
+        self.assertEqual(data["Role"], "TEAM")
+        self.assertEqual(data["Department"], "Administration")
 
     def test_template_unknown_department(self):
-        text = "\n".join([
-            "Имя (рус): Иван",
-            "Пол: M",
-            "Департамент: Support",
-        ])
+        text = "\n".join(
+            [
+                "Имя (рус): Иван",
+                "Пол: M",
+                "Департамент: Support",
+            ]
+        )
         data = parse_participant_data(text)
-        self.assertEqual(data['Department'], '')
+        self.assertEqual(data["Department"], "")
 
     def test_unstructured_multi_field(self):
-        cache.set('churches', ['Грейс'])
+        cache.set("churches", ["Грейс"])
         text = "Саша Б тим админ Грейс Хайфа"
         data = parse_unstructured_text(text)
-        self.assertEqual(data['FullNameRU'], 'Саша Б')
-        self.assertEqual(data['Role'], 'TEAM')
-        self.assertEqual(data['Department'], 'Administration')
-        self.assertEqual(data['Church'], 'Грейс')
-        self.assertEqual(data['CountryAndCity'], 'ХАЙФА')
+        self.assertEqual(data["FullNameRU"], "Саша Б")
+        self.assertEqual(data["Role"], "TEAM")
+        self.assertEqual(data["Department"], "Administration")
+        self.assertEqual(data["Church"], "Грейс")
+        self.assertEqual(data["CountryAndCity"], "ХАЙФА")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- harden email & phone validation logic
- use new validators when extracting contact info
- cover more contact parsing cases
- add tests for contacts with trailing punctuation
- support detailed Israeli phone formats
- integrate Israeli phone validation tests

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_688b61aa01048324b4a80b8f6a4dc1e9