### PR TITLE
fix: tighten israeli phone validation

### DIFF
--- a/tests/test_contact_validation.py
+++ b/tests/test_contact_validation.py
@@ -83,9 +83,14 @@ class IsraeliPhoneValidationTestCase(unittest.TestCase):
         )
         self.assertEqual(result["ContactInformation"], "02-123-4567")
 
+        result = parse_participant_data(
+            "Саша Басис муж L церковь Благодать кандидат хайфа +972312434412"
+        )
+        self.assertEqual(result["FullNameRU"], "Саша Басис")
+        self.assertEqual(result["ContactInformation"], "+972312434412")
+
         result = parse_participant_data("Ицхак Петров муж L церковь Грейс 051-123-4567")
         self.assertEqual(result["ContactInformation"], "")
-
 
 class ContactValidationTestCase(unittest.TestCase):
     def test_valid_emails(self):


### PR DESCRIPTION
## Summary
- refine phone validation to handle Israeli prefixes accurately
- clean up contact validation tests and remove duplication

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688b8fef32b083248cbeeec3d388af1b