### PR TITLE
Add return menu text toggle

### DIFF
--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -78,6 +78,7 @@ def format_participant_block(data: Dict) -> str:
 def get_edit_keyboard(participant_data: Dict) -> InlineKeyboardMarkup:
     """Создает клавиатуру с кнопками для редактирования полей."""
     buttons = [
+        [InlineKeyboardButton("✅ Сохранить", callback_data="confirm_save")],
         [
             InlineKeyboardButton("👤 Имя (рус)", callback_data="edit_FullNameRU"),
             InlineKeyboardButton("🌍 Имя (англ)", callback_data="edit_FullNameEN"),


### PR DESCRIPTION
## Summary
- update `_show_main_menu` to allow custom text when returning
- edit existing menu message when possible
- pass `is_return=True` from cancel handlers and main menu callback

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_688ba120e98c83248203df952ef69082