### PR TITLE
Fix parsing of empty gender values

### DIFF
--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -424,10 +424,15 @@ def parse_template_format(text: str) -> Dict:
         key, value = item.split(":", 1)
         key = key.strip()
         value = value.strip()
+        explicit_empty = False
         if value in ["➖ Не указано", "❌ Не указано"]:
             value = ""
+            explicit_empty = True
         for ru, eng in TEMPLATE_FIELD_MAP.items():
             if key.lower() == ru.lower():
+                if not value and not explicit_empty:
+                    # Skip unspecified values so we don't overwrite existing data
+                    break
                 norm = value or ""
                 if eng == "Gender":
                     norm = normalize_gender(value) or ""
@@ -813,8 +818,8 @@ class ParticipantParser:
         self._extract_names(all_words)
 
     def _postprocess_data(self):
-        if not self.data.get("Gender"):
-            self.data["Gender"] = "F"
+        """Finalize parsing results without forcing default values."""
+        pass
 
     def _extract_submitted_by(self, text: str):
         """Извлекает информацию о том, кто подал заявку."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,7 +16,7 @@ class ParserTestCase(unittest.TestCase):
         text = "Иван Петров M L церковь Новая Жизнь кандидат"
         data = parse_participant_data(text)
         self.assertEqual(data["FullNameRU"], "Иван Петров")
-        self.assertEqual(data["Gender"], "F")
+        self.assertEqual(data["Gender"], "")
         self.assertEqual(data["Size"], "M")
         self.assertEqual(data["Role"], "CANDIDATE")
 
@@ -128,7 +128,7 @@ class ParserTestCase(unittest.TestCase):
         data = parse_template_format(text)
         self.assertEqual(data["FullNameRU"], "Иван Петров")
         self.assertEqual(data["Gender"], "M")
-        self.assertEqual(data["Size"], "")
+        self.assertNotIn("Size", data)
         self.assertEqual(data["Church"], "Благодать")
 
     def test_parse_template_single_line_commas(self):
@@ -179,7 +179,7 @@ class ParserTestCase(unittest.TestCase):
     def test_m_gender_size_conflict_resolution(self):
         """Тест разрешения конфликта M между полом и размером"""
         result = parse_participant_data("Мария размер M церковь Грейс")
-        self.assertEqual(result["Gender"], "F")
+        self.assertEqual(result["Gender"], "")
         self.assertEqual(result["Size"], "M")
 
         result = parse_participant_data("Михаил пол M церковь Грейс")

--- a/tests/test_role_department_logic.py
+++ b/tests/test_role_department_logic.py
@@ -1,0 +1,33 @@
+import unittest
+from services.participant_service import merge_participant_data, detect_changes
+
+
+class RoleDepartmentLogicTestCase(unittest.TestCase):
+    def test_merge_clears_department_on_role_change(self):
+        existing = {
+            "FullNameRU": "Test User",
+            "Gender": "M",
+            "Church": "Test",
+            "Role": "TEAM",
+            "Department": "Worship",
+        }
+        updates = {"Role": "CANDIDATE"}
+        result = merge_participant_data(existing, updates)
+        self.assertEqual(result["Role"], "CANDIDATE")
+        self.assertEqual(result.get("Department"), "")
+
+    def test_detect_changes_shows_department_cleared(self):
+        old = {
+            "FullNameRU": "Test User",
+            "Role": "TEAM",
+            "Department": "Worship",
+        }
+        new = {"Role": "CANDIDATE"}
+        changes = detect_changes(old, new)
+        joined = " ".join(changes)
+        self.assertIn("Департамент", joined)
+        self.assertIn("Worship → —", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip empty fields when parsing template updates
- remove default gender assumption
- adjust parser tests

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688bcc559d608324ac5870ff4fe448bb