### PR TITLE
feat: add enum selection keyboards

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,63 @@ class Role(Enum):
     TEAM = "TEAM"
 
 
+# === DISPLAY_NAMES ===
+# Отображаемые названия для пользователей
+GENDER_DISPLAY = {"M": "Мужской", "F": "Женский"}
+ROLE_DISPLAY = {"CANDIDATE": "Кандидат", "TEAM": "Команда"}
+SIZE_DISPLAY = {
+    "XS": "XS",
+    "S": "S",
+    "M": "M",
+    "L": "L",
+    "XL": "XL",
+    "XXL": "XXL",
+    "3XL": "3XL",
+}
+
+DEPARTMENT_DISPLAY = {
+    "ROE": "РОЕ",
+    "Chapel": "Молитвенная",
+    "Setup": "Сетап",
+    "Palanka": "Паланка",
+    "Administration": "Администрация",
+    "Kitchen": "Кухня",
+    "Decoration": "Декорации",
+    "Bell": "Звонарь",
+    "Refreshment": "Рефрешмент",
+    "Worship": "Прославление",
+    "Media": "Медиа",
+    "Духовенство": "Духовенство",
+    "Ректорат": "Ректорат",
+}
+
+# Reverse lookups for parsing display names back to system keys
+DISPLAY_TO_GENDER = {v.lower(): k for k, v in GENDER_DISPLAY.items()}
+DISPLAY_TO_ROLE = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
+DISPLAY_TO_SIZE = {v.lower(): k for k, v in SIZE_DISPLAY.items()}
+DISPLAY_TO_DEPARTMENT = {v.lower(): k for k, v in DEPARTMENT_DISPLAY.items()}
+
+
+def gender_from_display(name: str) -> str:
+    """Return internal gender key for a Russian display name."""
+    return DISPLAY_TO_GENDER.get(name.strip().lower(), "")
+
+
+def role_from_display(name: str) -> str:
+    """Return internal role key for a Russian display name."""
+    return DISPLAY_TO_ROLE.get(name.strip().lower(), "")
+
+
+def size_from_display(name: str) -> str:
+    """Return internal size key for a Russian display name."""
+    return DISPLAY_TO_SIZE.get(name.strip().lower(), "")
+
+
+def department_from_display(name: str) -> str:
+    """Return internal department key for a Russian display name."""
+    return DISPLAY_TO_DEPARTMENT.get(name.strip().lower(), "")
+
+
 ISRAEL_CITIES = [
     "ХАЙФА",
     "HAIFA",

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -19,6 +19,12 @@ from utils.recognizers import (
     recognize_church,
     recognize_city,
 )
+from constants import (
+    gender_from_display,
+    role_from_display,
+    size_from_display,
+    department_from_display,
+)
 
 
 @dataclass
@@ -435,13 +441,17 @@ def parse_template_format(text: str) -> Dict:
                     break
                 norm = value or ""
                 if eng == "Gender":
-                    norm = normalize_gender(value) or ""
+                    norm = gender_from_display(value) or normalize_gender(value) or ""
                 elif eng == "Role":
-                    norm = normalize_role(value) or ""
+                    norm = role_from_display(value) or normalize_role(value) or ""
                 elif eng == "Department":
-                    norm = normalize_department(value) or ""
+                    norm = (
+                        department_from_display(value)
+                        or normalize_department(value)
+                        or ""
+                    )
                 elif eng == "Size":
-                    norm = normalize_size(value) or ""
+                    norm = size_from_display(value) or normalize_size(value) or ""
                 data[eng] = norm
                 break
     logger.debug("parse_template_format parsed fields: %s", list(data.keys()))
@@ -972,11 +982,7 @@ class ParticipantParser:
                         church_words.append(all_words[i + 2])
                         self.processed_words.add(all_words[i + 2])
                 # Remove any identifier words
-                cleaned = [
-                    w
-                    for w in church_words
-                    if w.upper() not in CHURCH_KEYWORDS
-                ]
+                cleaned = [w for w in church_words if w.upper() not in CHURCH_KEYWORDS]
                 self.data["Church"] = " ".join(cleaned)
                 return  # Нашли через ключевые слова - выходим
 

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -13,6 +13,12 @@ from utils.exceptions import (
     ValidationError,
 )
 from parsers.participant_parser import normalize_field_value
+from constants import (
+    GENDER_DISPLAY,
+    ROLE_DISPLAY,
+    SIZE_DISPLAY,
+    DEPARTMENT_DISPLAY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,22 +79,97 @@ def merge_participant_data(
 
 
 def format_participant_block(data: Dict) -> str:
+    gender_key = data.get("Gender") or ""
+    size_key = data.get("Size") or ""
+    role_key = data.get("Role") or ""
+    dept_key = data.get("Department") or ""
+
+    gender = GENDER_DISPLAY.get(gender_key, "Не указано")
+    size = SIZE_DISPLAY.get(size_key, "Не указано")
+    role = ROLE_DISPLAY.get(role_key, role_key)
+    department = DEPARTMENT_DISPLAY.get(dept_key, dept_key or "Не указано")
+
     text = (
         f"Имя (рус): {data.get('FullNameRU') or 'Не указано'}\n"
         f"Имя (англ): {data.get('FullNameEN') or 'Не указано'}\n"
-        f"Пол: {data.get('Gender')}\n"
-        f"Размер: {data.get('Size') or 'Не указано'}\n"
+        f"Пол: {gender}\n"
+        f"Размер: {size}\n"
         f"Церковь: {data.get('Church') or 'Не указано'}\n"
-        f"Роль: {data.get('Role')}"
+        f"Роль: {role}"
     )
-    if data.get("Role") == "TEAM":
-        text += f"\nДепартамент: {data.get('Department') or 'Не указано'}"
+
+    if role_key == "TEAM":
+        text += f"\nДепартамент: {department}"
+
     text += (
         f"\nГород: {data.get('CountryAndCity') or 'Не указано'}\n"
         f"Кто подал: {data.get('SubmittedBy') or 'Не указано'}\n"
         f"Контакты: {data.get('ContactInformation') or 'Не указано'}"
     )
     return text
+
+
+def get_gender_selection_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для выбора пола."""
+    buttons = [
+        [InlineKeyboardButton("\U0001f468 Мужской", callback_data="gender_M")],
+        [InlineKeyboardButton("\U0001f469 Женский", callback_data="gender_F")],
+        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_role_selection_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для выбора роли."""
+    buttons = [
+        [InlineKeyboardButton("\U0001f464 Кандидат", callback_data="role_CANDIDATE")],
+        [InlineKeyboardButton("\U0001f465 Команда", callback_data="role_TEAM")],
+        [InlineKeyboardButton("✏️ Ввести вручную", callback_data="manual_input_Role")],
+        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_size_selection_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для выбора размера."""
+    buttons = [
+        [
+            InlineKeyboardButton("XS", callback_data="size_XS"),
+            InlineKeyboardButton("S", callback_data="size_S"),
+            InlineKeyboardButton("M", callback_data="size_M"),
+        ],
+        [
+            InlineKeyboardButton("L", callback_data="size_L"),
+            InlineKeyboardButton("XL", callback_data="size_XL"),
+            InlineKeyboardButton("XXL", callback_data="size_XXL"),
+        ],
+        [InlineKeyboardButton("3XL", callback_data="size_3XL")],
+        [InlineKeyboardButton("✏️ Ввести вручную", callback_data="manual_input_Size")],
+        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_department_selection_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для выбора департамента."""
+    buttons = []
+    dept_items = list(DEPARTMENT_DISPLAY.items())
+    for i in range(0, len(dept_items), 2):
+        row = []
+        for j in range(i, min(i + 2, len(dept_items))):
+            key, display_name = dept_items[j]
+            row.append(InlineKeyboardButton(display_name, callback_data=f"dept_{key}"))
+        buttons.append(row)
+
+    buttons.append(
+        [
+            InlineKeyboardButton(
+                "✏️ Ввести вручную", callback_data="manual_input_Department"
+            )
+        ]
+    )
+    buttons.append([InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")])
+    return InlineKeyboardMarkup(buttons)
 
 
 def get_edit_keyboard(participant_data: Dict) -> InlineKeyboardMarkup:
@@ -123,7 +204,9 @@ def get_edit_keyboard(participant_data: Dict) -> InlineKeyboardMarkup:
     buttons.append(
         [
             InlineKeyboardButton("👨‍💼 Кто подал", callback_data="edit_SubmittedBy"),
-            InlineKeyboardButton("📞 Контакты", callback_data="edit_ContactInformation"),
+            InlineKeyboardButton(
+                "📞 Контакты", callback_data="edit_ContactInformation"
+            ),
         ]
     )
 

--- a/tests/test_confirmation_template.py
+++ b/tests/test_confirmation_template.py
@@ -1,45 +1,66 @@
 import unittest
 from parsers.participant_parser import parse_template_format
 
+
 class ConfirmationTemplateTestCase(unittest.TestCase):
     def test_basic_parse(self):
-        text = "\n".join([
-            "Имя (рус): Ирина Цой",
-            "Пол: F",
-            "Размер: M",
-        ])
+        text = "\n".join(
+            [
+                "Имя (рус): Ирина Цой",
+                "Пол: F",
+                "Размер: M",
+            ]
+        )
         data = parse_template_format(text)
-        self.assertEqual(data, {
-            'FullNameRU': 'Ирина Цой',
-            'Gender': 'F',
-            'Size': 'M'
-        })
+        self.assertEqual(data, {"FullNameRU": "Ирина Цой", "Gender": "F", "Size": "M"})
 
     def test_ignore_service_values(self):
-        text = "\n".join([
-            "Имя (рус): Ирина Цой",
-            "Пол: F",
-            "Размер: ❌ Не указано",
-            "Департамент: ➖ Не указано",
-        ])
+        text = "\n".join(
+            [
+                "Имя (рус): Ирина Цой",
+                "Пол: F",
+                "Размер: ❌ Не указано",
+                "Департамент: ➖ Не указано",
+            ]
+        )
         data = parse_template_format(text)
-        self.assertEqual(data, {
-            'FullNameRU': 'Ирина Цой',
-            'Gender': 'F',
-            'Size': '',
-            'Department': ''
-        })
+        self.assertEqual(
+            data,
+            {"FullNameRU": "Ирина Цой", "Gender": "F", "Size": "", "Department": ""},
+        )
 
     def test_church_parsing(self):
-        text = "\n".join([
-            "Имя (рус): Ирина Цой",
-            "Церковь: церковь Грейс",
-        ])
+        text = "\n".join(
+            [
+                "Имя (рус): Ирина Цой",
+                "Церковь: церковь Грейс",
+            ]
+        )
         data = parse_template_format(text)
-        self.assertEqual(data, {
-            'FullNameRU': 'Ирина Цой',
-            'Church': 'церковь Грейс'
-        })
+        self.assertEqual(data, {"FullNameRU": "Ирина Цой", "Church": "церковь Грейс"})
 
-if __name__ == '__main__':
+    def test_parse_display_values(self):
+        text = "\n".join(
+            [
+                "Имя (рус): Тест Тестов",
+                "Пол: Мужской",
+                "Роль: Команда",
+                "Департамент: Кухня",
+                "Размер: XL",
+            ]
+        )
+        data = parse_template_format(text)
+        self.assertEqual(
+            data,
+            {
+                "FullNameRU": "Тест Тестов",
+                "Gender": "M",
+                "Role": "TEAM",
+                "Department": "Kitchen",
+                "Size": "XL",
+            },
+        )
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_edit_keyboard.py
+++ b/tests/test_edit_keyboard.py
@@ -1,5 +1,11 @@
 import unittest
-from services.participant_service import get_edit_keyboard
+from services.participant_service import (
+    get_edit_keyboard,
+    get_gender_selection_keyboard,
+    get_role_selection_keyboard,
+    get_size_selection_keyboard,
+    get_department_selection_keyboard,
+)
 
 
 class EditKeyboardTestCase(unittest.TestCase):
@@ -9,7 +15,9 @@ class EditKeyboardTestCase(unittest.TestCase):
         datas = [b.callback_data for row in rows for b in row]
         self.assertIn("edit_Role", datas)
         self.assertNotIn("edit_Department", datas)
-        role_row = next(row for row in rows if any(b.callback_data == "edit_Role" for b in row))
+        role_row = next(
+            row for row in rows if any(b.callback_data == "edit_Role" for b in row)
+        )
         self.assertEqual(len(role_row), 1)
 
     def test_team_shows_department(self):
@@ -17,8 +25,38 @@ class EditKeyboardTestCase(unittest.TestCase):
         rows = kb.inline_keyboard
         datas = [b.callback_data for row in rows for b in row]
         self.assertIn("edit_Department", datas)
-        role_row = next(row for row in rows if any(b.callback_data == "edit_Role" for b in row))
+        role_row = next(
+            row for row in rows if any(b.callback_data == "edit_Role" for b in row)
+        )
         self.assertEqual(len(role_row), 2)
+
+    def test_gender_selection_keyboard(self):
+        kb = get_gender_selection_keyboard()
+        datas = [b.callback_data for row in kb.inline_keyboard for b in row]
+        self.assertIn("gender_M", datas)
+        self.assertIn("gender_F", datas)
+        self.assertIn("main_cancel", datas)
+
+    def test_role_selection_keyboard(self):
+        kb = get_role_selection_keyboard()
+        datas = [b.callback_data for row in kb.inline_keyboard for b in row]
+        self.assertIn("role_CANDIDATE", datas)
+        self.assertIn("role_TEAM", datas)
+        self.assertIn("manual_input_Role", datas)
+
+    def test_size_selection_keyboard(self):
+        kb = get_size_selection_keyboard()
+        datas = [b.callback_data for row in kb.inline_keyboard for b in row]
+        self.assertIn("size_XS", datas)
+        self.assertIn("size_M", datas)
+        self.assertIn("manual_input_Size", datas)
+
+    def test_department_selection_keyboard(self):
+        kb = get_department_selection_keyboard()
+        datas = [b.callback_data for row in kb.inline_keyboard for b in row]
+        self.assertIn("dept_ROE", datas)
+        self.assertIn("dept_Kitchen", datas)
+        self.assertIn("manual_input_Department", datas)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement inline keyboards for enum fields
- support enum selections in edit confirmation flow
- update confirmation display function to work for callbacks
- add unit tests for selection keyboards

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688c8a36024c832490c4650a9a2f5587