### PR TITLE
fix: add cancel handler tests

### DIFF
--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -114,7 +114,7 @@ def get_gender_selection_keyboard() -> InlineKeyboardMarkup:
     buttons = [
         [InlineKeyboardButton("\U0001f468 Мужской", callback_data="gender_M")],
         [InlineKeyboardButton("\U0001f469 Женский", callback_data="gender_F")],
-        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
     ]
     return InlineKeyboardMarkup(buttons)
 
@@ -125,7 +125,7 @@ def get_role_selection_keyboard() -> InlineKeyboardMarkup:
         [InlineKeyboardButton("\U0001f464 Кандидат", callback_data="role_CANDIDATE")],
         [InlineKeyboardButton("\U0001f465 Команда", callback_data="role_TEAM")],
         [InlineKeyboardButton("✏️ Ввести вручную", callback_data="manual_input_Role")],
-        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
     ]
     return InlineKeyboardMarkup(buttons)
 
@@ -145,7 +145,7 @@ def get_size_selection_keyboard() -> InlineKeyboardMarkup:
         ],
         [InlineKeyboardButton("3XL", callback_data="size_3XL")],
         [InlineKeyboardButton("✏️ Ввести вручную", callback_data="manual_input_Size")],
-        [InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
     ]
     return InlineKeyboardMarkup(buttons)
 
@@ -168,7 +168,7 @@ def get_department_selection_keyboard() -> InlineKeyboardMarkup:
             )
         ]
     )
-    buttons.append([InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")])
+    buttons.append([InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")])
     return InlineKeyboardMarkup(buttons)
 
 

--- a/tests/test_edit_keyboard.py
+++ b/tests/test_edit_keyboard.py
@@ -35,7 +35,7 @@ class EditKeyboardTestCase(unittest.TestCase):
         datas = [b.callback_data for row in kb.inline_keyboard for b in row]
         self.assertIn("gender_M", datas)
         self.assertIn("gender_F", datas)
-        self.assertIn("main_cancel", datas)
+        self.assertIn("field_edit_cancel", datas)
 
     def test_role_selection_keyboard(self):
         kb = get_role_selection_keyboard()
@@ -43,6 +43,7 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertIn("role_CANDIDATE", datas)
         self.assertIn("role_TEAM", datas)
         self.assertIn("manual_input_Role", datas)
+        self.assertIn("field_edit_cancel", datas)
 
     def test_size_selection_keyboard(self):
         kb = get_size_selection_keyboard()
@@ -50,6 +51,7 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertIn("size_XS", datas)
         self.assertIn("size_M", datas)
         self.assertIn("manual_input_Size", datas)
+        self.assertIn("field_edit_cancel", datas)
 
     def test_department_selection_keyboard(self):
         kb = get_department_selection_keyboard()
@@ -57,6 +59,7 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertIn("dept_ROE", datas)
         self.assertIn("dept_Kitchen", datas)
         self.assertIn("manual_input_Department", datas)
+        self.assertIn("field_edit_cancel", datas)
 
 
 if __name__ == "__main__":

--- a/tests/test_field_edit_cancel.py
+++ b/tests/test_field_edit_cancel.py
@@ -1,0 +1,31 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from main import handle_field_edit_cancel, CONFIRMING_DATA
+
+
+class FieldEditCancelTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_cancel_returns_to_confirmation(self):
+        query = MagicMock()
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        query.message = MagicMock()
+        query.message.reply_text = AsyncMock()
+        update = SimpleNamespace(callback_query=query,
+                                 effective_user=SimpleNamespace(id=1))
+        context = SimpleNamespace(user_data={'parsed_participant': {'Role': 'TEAM'}},
+                                  bot=None)
+
+        with patch('main.show_confirmation', new=AsyncMock()) as mock_show, \
+             patch('main.get_edit_keyboard', return_value='kb'):
+            state = await handle_field_edit_cancel(update, context)
+
+        mock_show.assert_awaited_once()
+        query.edit_message_text.assert_awaited_once()
+        self.assertEqual(state, CONFIRMING_DATA)
+        self.assertNotIn('field_to_edit', context.user_data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve cancel flow with a back message
- verify enum keyboards expose the `field_edit_cancel` callback
- add async test for the cancel handler

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_688ca5b1def883248f9633185574b515