### PR TITLE
Remove manual size input

### DIFF
--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -431,6 +431,15 @@ TEMPLATE_FIELD_MAP = {
     "Контакты": "ContactInformation",
 }
 
+# Mapping of Cyrillic size abbreviations to Latin equivalents for template parsing
+CYRILLIC_TO_LATIN = {
+    "м": "M",
+    "л": "L",
+    "с": "S",
+    "хс": "XS",
+    "хл": "XL",
+}
+
 
 def is_template_format(text: str) -> bool:
     """Определяет, похоже ли сообщение на заполненный шаблон."""
@@ -479,6 +488,7 @@ def parse_template_format(text: str) -> Dict:
                         or ""
                     )
                 elif eng == "Size":
+                    value = CYRILLIC_TO_LATIN.get(value.lower(), value)
                     norm = size_from_display(value) or normalize_size(value) or ""
                 data[eng] = norm
                 break

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -130,8 +130,28 @@ def get_role_selection_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(buttons)
 
 
-def get_size_selection_keyboard() -> InlineKeyboardMarkup:
-    """Клавиатура для выбора размера."""
+def get_gender_selection_keyboard_required() -> InlineKeyboardMarkup:
+    """Keyboard for gender selection without manual input."""
+    buttons = [
+        [InlineKeyboardButton("\U0001f468 Мужской", callback_data="gender_M")],
+        [InlineKeyboardButton("\U0001f469 Женский", callback_data="gender_F")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_role_selection_keyboard_required() -> InlineKeyboardMarkup:
+    """Keyboard for role selection without manual input."""
+    buttons = [
+        [InlineKeyboardButton("\U0001f464 Кандидат", callback_data="role_CANDIDATE")],
+        [InlineKeyboardButton("\U0001f465 Команда", callback_data="role_TEAM")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_size_selection_keyboard_required() -> InlineKeyboardMarkup:
+    """Keyboard for size selection without manual input."""
     buttons = [
         [
             InlineKeyboardButton("XS", callback_data="size_XS"),
@@ -144,7 +164,52 @@ def get_size_selection_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton("XXL", callback_data="size_XXL"),
         ],
         [InlineKeyboardButton("3XL", callback_data="size_3XL")],
-        [InlineKeyboardButton("✏️ Ввести вручную", callback_data="manual_input_Size")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_department_selection_keyboard_required() -> InlineKeyboardMarkup:
+    """Keyboard for department selection without manual input."""
+    buttons = []
+    dept_items = list(DEPARTMENT_DISPLAY.items())
+    for i in range(0, len(dept_items), 2):
+        row = []
+        for j in range(i, min(i + 2, len(dept_items))):
+            key, display_name = dept_items[j]
+            row.append(
+                InlineKeyboardButton(display_name, callback_data=f"dept_{key}")
+            )
+        buttons.append(row)
+
+    buttons.append([InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")])
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_size_selection_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для выбора размера без ручного ввода."""
+    buttons = [
+        [
+            InlineKeyboardButton("XS", callback_data="size_XS"),
+            InlineKeyboardButton("S", callback_data="size_S"),
+            InlineKeyboardButton("M", callback_data="size_M"),
+        ],
+        [
+            InlineKeyboardButton("L", callback_data="size_L"),
+            InlineKeyboardButton("XL", callback_data="size_XL"),
+            InlineKeyboardButton("XXL", callback_data="size_XXL"),
+        ],
+        [InlineKeyboardButton("3XL", callback_data="size_3XL")],
+        [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+def get_gender_selection_keyboard_simple() -> InlineKeyboardMarkup:
+    """Keyboard for gender selection without manual input."""
+    buttons = [
+        [InlineKeyboardButton("\U0001f468 Мужской", callback_data="gender_M")],
+        [InlineKeyboardButton("\U0001f469 Женский", callback_data="gender_F")],
         [InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")],
     ]
     return InlineKeyboardMarkup(buttons)

--- a/states.py
+++ b/states.py
@@ -5,3 +5,6 @@ GETTING_DATA, CONFIRMING_DATA, CONFIRMING_DUPLICATE, COLLECTING_DATA = range(4)
 
 # Состояние для пошагового заполнения недостающих полей
 FILLING_MISSING_FIELDS = 5
+
+# Состояние восстановления после технических ошибок
+RECOVERING = 6

--- a/tests/test_edit_keyboard.py
+++ b/tests/test_edit_keyboard.py
@@ -1,10 +1,14 @@
 import unittest
 from services.participant_service import (
     get_edit_keyboard,
-    get_gender_selection_keyboard,
+    get_gender_selection_keyboard_simple,
     get_role_selection_keyboard,
     get_size_selection_keyboard,
     get_department_selection_keyboard,
+    get_gender_selection_keyboard_required,
+    get_role_selection_keyboard_required,
+    get_size_selection_keyboard_required,
+    get_department_selection_keyboard_required,
 )
 
 
@@ -31,7 +35,7 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertEqual(len(role_row), 2)
 
     def test_gender_selection_keyboard(self):
-        kb = get_gender_selection_keyboard()
+        kb = get_gender_selection_keyboard_simple()
         datas = [b.callback_data for row in kb.inline_keyboard for b in row]
         self.assertIn("gender_M", datas)
         self.assertIn("gender_F", datas)
@@ -50,7 +54,6 @@ class EditKeyboardTestCase(unittest.TestCase):
         datas = [b.callback_data for row in kb.inline_keyboard for b in row]
         self.assertIn("size_XS", datas)
         self.assertIn("size_M", datas)
-        self.assertIn("manual_input_Size", datas)
         self.assertIn("field_edit_cancel", datas)
 
     def test_department_selection_keyboard(self):
@@ -60,6 +63,23 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertIn("dept_Kitchen", datas)
         self.assertIn("manual_input_Department", datas)
         self.assertIn("field_edit_cancel", datas)
+
+    def test_required_keyboards_no_manual_input(self):
+        kb_role = get_role_selection_keyboard_required()
+        datas_role = [b.callback_data for row in kb_role.inline_keyboard for b in row]
+        self.assertNotIn("manual_input_Role", datas_role)
+
+        kb_size = get_size_selection_keyboard_required()
+        datas_size = [b.callback_data for row in kb_size.inline_keyboard for b in row]
+        self.assertNotIn("manual_input_Size", datas_size)
+
+        kb_dept = get_department_selection_keyboard_required()
+        datas_dept = [b.callback_data for row in kb_dept.inline_keyboard for b in row]
+        self.assertNotIn("manual_input_Department", datas_dept)
+
+        kb_gender = get_gender_selection_keyboard_required()
+        datas_gender = [b.callback_data for row in kb_gender.inline_keyboard for b in row]
+        self.assertNotIn("manual_input_Gender", datas_gender)
 
 
 if __name__ == "__main__":

--- a/tests/test_enum_selection_context.py
+++ b/tests/test_enum_selection_context.py
@@ -1,0 +1,68 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from main import handle_enum_selection, FILLING_MISSING_FIELDS, CONFIRMING_DATA
+
+
+class EnumSelectionContextTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_continue_missing_fields(self):
+        query = MagicMock()
+        query.answer = AsyncMock()
+        query.message = MagicMock()
+        query.message.reply_text = AsyncMock()
+        query.data = "gender_M"
+        update = SimpleNamespace(
+            callback_query=query, effective_user=SimpleNamespace(id=1)
+        )
+        context = SimpleNamespace(
+            user_data={
+                "add_flow_data": {"Gender": None, "Role": None},
+                "current_state": CONFIRMING_DATA,
+                "filling_missing_field": True,
+            }
+        )
+        with patch(
+            "main.show_interactive_missing_field", new=AsyncMock()
+        ) as mock_show, patch("main.show_confirmation", new=AsyncMock()) as mock_conf:
+            state = await handle_enum_selection(update, context)
+        mock_show.assert_awaited_once()
+        mock_conf.assert_not_awaited()
+        self.assertEqual(state, FILLING_MISSING_FIELDS)
+        self.assertEqual(context.user_data["add_flow_data"]["Gender"], "M")
+
+    async def test_finish_missing_fields(self):
+        query = MagicMock()
+        query.answer = AsyncMock()
+        query.message = MagicMock()
+        query.message.reply_text = AsyncMock()
+        query.data = "role_TEAM"
+        update = SimpleNamespace(
+            callback_query=query, effective_user=SimpleNamespace(id=1)
+        )
+        context = SimpleNamespace(
+            user_data={
+                "add_flow_data": {
+                    "FullNameRU": "Test",
+                    "Gender": "M",
+                    "Size": "L",
+                    "Church": "Grace",
+                    "Role": None,
+                    "Department": "Worship",
+                },
+                "current_state": CONFIRMING_DATA,
+                "filling_missing_field": True,
+            }
+        )
+        with patch(
+            "main.show_interactive_missing_field", new=AsyncMock()
+        ) as mock_show, patch("main.show_confirmation", new=AsyncMock()) as mock_conf:
+            state = await handle_enum_selection(update, context)
+        mock_show.assert_not_awaited()
+        mock_conf.assert_awaited_once()
+        self.assertEqual(state, CONFIRMING_DATA)
+        self.assertFalse(context.user_data.get("filling_missing_field", True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,6 +54,11 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(data["Size"], "L")
         self.assertEqual(data["Church"], "Благодать")
 
+    def test_template_cyrillic_size_m(self):
+        text = "Имя (рус): Иван Петров, Размер: м"
+        data = parse_template_format(text)
+        self.assertEqual(data["Size"], "M")
+
     def test_medium_size_not_in_submitted_by(self):
         """Тест проверяет, что 'medium' распознается как размер, а не как часть имени подавшего"""
         text = "Тест Басис тим админ община грейс муж Хайфа от Ирина Цой medium"

--- a/tests/test_recover.py
+++ b/tests/test_recover.py
@@ -1,0 +1,51 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from main import (
+    recover_from_technical_error,
+    smart_cleanup_on_error,
+    CONFIRMING_DATA,
+    RECOVERING,
+    get_recovery_keyboard,
+)
+
+
+class RecoverTechnicalErrorTestCase(unittest.IsolatedAsyncioTestCase):
+    async def test_recover_function_returns_state(self):
+        message = MagicMock()
+        update = SimpleNamespace(message=message, callback_query=None, effective_user=SimpleNamespace(id=1))
+        context = SimpleNamespace(user_data={"current_state": CONFIRMING_DATA})
+        with patch("main.show_recovery_options", new=AsyncMock(return_value=RECOVERING)) as mock_show:
+            state = await recover_from_technical_error(update, context)
+        mock_show.assert_awaited_once()
+        self.assertEqual(state, RECOVERING)
+
+    async def test_decorator_handles_jobqueue_error(self):
+        async def failing(update, context):
+            raise AttributeError("job_queue missing")
+
+        decorated = smart_cleanup_on_error(failing)
+
+        update = SimpleNamespace(message=MagicMock(), callback_query=None, effective_user=SimpleNamespace(id=1))
+        update.message.reply_text = AsyncMock()
+        context = SimpleNamespace(user_data={"current_state": CONFIRMING_DATA})
+
+        with patch("main.recover_from_technical_error", new=AsyncMock(return_value=RECOVERING)) as mock_recover:
+            state = await decorated(update, context)
+
+        mock_recover.assert_awaited_once()
+        self.assertEqual(state, RECOVERING)
+        self.assertIn("current_state", context.user_data)
+
+    def test_recovery_keyboard_buttons(self):
+        context = SimpleNamespace(user_data={"parsed_participant": {"Role": "TEAM"}, "add_flow_data": {"Size": "M"}})
+        kb = get_recovery_keyboard(context)
+        datas = [b.callback_data for row in kb.inline_keyboard for b in row]
+        self.assertIn("recover_confirmation", datas)
+        self.assertIn("recover_input", datas)
+        self.assertIn("main_add", datas)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from utils.timeouts import set_edit_timeout, is_edit_expired, clear_expired_edit
 import time
 
@@ -16,6 +17,28 @@ class TimeoutsTestCase(unittest.TestCase):
         cleared = clear_expired_edit(self.context)
         self.assertTrue(cleared)
         self.assertNotIn("field_to_edit", self.context.user_data)
+
+
+class SafeTimeoutJobTestCase(unittest.TestCase):
+    def test_safe_job_creation_no_queue(self):
+        from main import safe_create_timeout_job
+
+        context = SimpleNamespace(user_data={}, job_queue=None)
+        job = safe_create_timeout_job(context, lambda x: x, 5, user_id=1)
+        self.assertIsNone(job)
+        self.assertIn("edit_timeout", context.user_data)
+
+    def test_safe_job_creation_with_queue(self):
+        from main import safe_create_timeout_job
+
+        mock_job = object()
+        job_queue = MagicMock()
+        job_queue.run_once.return_value = mock_job
+        context = SimpleNamespace(user_data={}, job_queue=job_queue)
+
+        job = safe_create_timeout_job(context, lambda x: x, 5, user_id=2)
+        job_queue.run_once.assert_called_once()
+        self.assertIs(job, mock_job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop manual input option for size edits
- provide simplified gender keyboard for edit flow
- update edit callback to use new keyboards
- adjust keyboard tests
- introduce recovery state so users can resume after technical issues

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_688cc5347c988324b813a1228bd5354f