### PR TITLE
Fix validation of required fields

### DIFF
--- a/models/participant.py
+++ b/models/participant.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
+
 @dataclass
 class Participant:
     # Required field without a default
@@ -10,7 +11,7 @@ class Participant:
     Gender: str = "F"
     Size: str = ""
     Church: str = ""
-    Role: str = "CANDIDATE"
+    Role: str = ""
     Department: str = ""
     FullNameEN: str = ""
     SubmittedBy: str = ""

--- a/parsers/participant_parser.py
+++ b/parsers/participant_parser.py
@@ -504,11 +504,15 @@ def _smart_name_classification(words):
         english_parts = []
 
         for word in words:
+            # Исключаем слова с цифрами из имен
+            if any(char.isdigit() for char in word):
+                continue  # пропускаем цифровые токены
+
             # Убираем дефисы для проверки, что остались только буквы
             cleaned = word.replace("-", "")
             if cleaned.isalpha() and word.isascii():
                 english_parts.append(word)
-            else:
+            elif cleaned.isalpha():
                 russian_parts.append(word)
 
         return russian_parts, english_parts
@@ -522,6 +526,10 @@ def _smart_name_classification(words):
     current_type = None
 
     for word in words:
+        # Исключаем слова с цифрами из имен
+        if any(char.isdigit() for char in word):
+            continue  # пропускаем цифровые токены
+
         # Убираем дефисы для проверки, что остались только буквы
         cleaned = word.replace("-", "")
         word_type = "english" if (cleaned.isalpha() and word.isascii()) else "russian"
@@ -824,7 +832,7 @@ class ParticipantParser:
             "Gender": "",
             "Size": "",
             "Church": "",
-            "Role": "CANDIDATE",
+            "Role": "",
             "Department": "",
             "FullNameEN": "",
             "SubmittedBy": "",
@@ -1051,8 +1059,11 @@ class ParticipantParser:
 
         unprocessed_words = [w for w in all_words if w not in self.processed_words]
 
-        if unprocessed_words:
-            russian_parts, english_parts = _smart_name_classification(unprocessed_words)
+        # Убираем токены с цифрами перед классификацией имен
+        name_tokens = [w for w in unprocessed_words if not any(c.isdigit() for c in w)]
+
+        if name_tokens:
+            russian_parts, english_parts = _smart_name_classification(name_tokens)
 
             if russian_parts:
                 self.data["FullNameRU"] = " ".join(russian_parts)
@@ -1083,6 +1094,6 @@ def normalize_field_value(field_name: str, value: str) -> str:
         return normalize_size(value) or ""
 
     if field_name == "Role":
-        return normalize_role(value) or "CANDIDATE"
+        return normalize_role(value) or ""
 
     return value

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -75,6 +75,14 @@ def merge_participant_data(
     if old_role == "TEAM" and merged.get("Role") == "CANDIDATE":
         merged["Department"] = ""
 
+    # Also clear department when switching to TEAM without specifying department
+    if (
+        old_role != "TEAM"
+        and merged.get("Role") == "TEAM"
+        and "Department" not in updates
+    ):
+        merged["Department"] = ""
+
     return merged
 
 
@@ -176,9 +184,7 @@ def get_department_selection_keyboard_required() -> InlineKeyboardMarkup:
         row = []
         for j in range(i, min(i + 2, len(dept_items))):
             key, display_name = dept_items[j]
-            row.append(
-                InlineKeyboardButton(display_name, callback_data=f"dept_{key}")
-            )
+            row.append(InlineKeyboardButton(display_name, callback_data=f"dept_{key}"))
         buttons.append(row)
 
     buttons.append([InlineKeyboardButton("↩️ Назад", callback_data="field_edit_cancel")])
@@ -331,6 +337,9 @@ def update_single_field(
 
     updated = participant_data.copy()
     updated[field_name] = normalized
+
+    if field_name == "Role" and normalized != original.get("Role"):
+        updated["Department"] = ""
 
     changes = detect_changes(original, updated)
     return updated, changes

--- a/tests/test_missing_fields.py
+++ b/tests/test_missing_fields.py
@@ -1,0 +1,22 @@
+import unittest
+
+from main import get_missing_fields, get_missing_field_keys
+from services.participant_service import FIELD_LABELS
+
+class MissingFieldsTestCase(unittest.TestCase):
+    def test_department_required_for_team(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "TEAM",
+            "Department": "",
+        }
+        fields = get_missing_field_keys(data)
+        self.assertIn("Department", fields)
+        labels = get_missing_fields(data)
+        self.assertIn(FIELD_LABELS["Department"], labels)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_normalize_field_value.py
+++ b/tests/test_normalize_field_value.py
@@ -3,30 +3,32 @@ from parsers.participant_parser import normalize_field_value
 
 # Нормализатор инициализируется автоматически, не нужно загружать кэш
 
+
 class NormalizeFieldValueTestCase(unittest.TestCase):
     def test_unknown_department(self):
-        self.assertEqual(normalize_field_value('Department', 'лалалал'), '')
+        self.assertEqual(normalize_field_value("Department", "лалалал"), "")
 
     def test_unknown_gender(self):
-        self.assertEqual(normalize_field_value('Gender', 'неизвестно'), '')
+        self.assertEqual(normalize_field_value("Gender", "неизвестно"), "")
 
     def test_unknown_size(self):
-        self.assertEqual(normalize_field_value('Size', 'большой'), '')
+        self.assertEqual(normalize_field_value("Size", "большой"), "")
 
     def test_unknown_role(self):
-        self.assertEqual(normalize_field_value('Role', 'работник'), 'CANDIDATE')
+        self.assertEqual(normalize_field_value("Role", "работник"), "")
 
     def test_known_department_synonym(self):
-        self.assertEqual(normalize_field_value('Department', 'админ'), 'Administration')
+        self.assertEqual(normalize_field_value("Department", "админ"), "Administration")
 
     def test_known_gender_synonym(self):
-        self.assertEqual(normalize_field_value('Gender', 'муж'), 'M')
+        self.assertEqual(normalize_field_value("Gender", "муж"), "M")
 
     def test_known_size_synonym(self):
-        self.assertEqual(normalize_field_value('Size', 'medium'), 'M')
+        self.assertEqual(normalize_field_value("Size", "medium"), "M")
 
     def test_known_role_synonym(self):
-        self.assertEqual(normalize_field_value('Role', 'тим'), 'TEAM')
+        self.assertEqual(normalize_field_value("Role", "тим"), "TEAM")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -285,6 +285,19 @@ class ParserTestCase(unittest.TestCase):
         self.assertEqual(data["FullNameRU"], "Анна-Мария Петрова-Сидорова")
         self.assertEqual(data["FullNameEN"], "Anne-Marie Johnson")
 
+    def test_digits_not_included_in_name(self):
+        """Цифровые токены не должны попадать в имя"""
+        text = "38833882 Иван Петров"
+        data = parse_participant_data(text)
+
+        self.assertEqual(data["FullNameRU"], "Иван Петров")
+        self.assertEqual(data["ContactInformation"], "")
+
+        text2 = "Иван 38833882 Петров"
+        data2 = parse_participant_data(text2)
+        self.assertEqual(data2["FullNameRU"], "Иван Петров")
+        self.assertEqual(data2["ContactInformation"], "")
+
 
 class SmartNameClassificationTestCase(unittest.TestCase):
     def test_simple_cases(self):
@@ -334,6 +347,11 @@ class SmartNameClassificationTestCase(unittest.TestCase):
         ru, en = _smart_name_classification(["Анна-Мария", "Anne-Marie"])
         self.assertEqual(ru, ["Анна-Мария"])
         self.assertEqual(en, ["Anne-Marie"])
+
+        # Токены с цифрами должны игнорироваться
+        ru, en = _smart_name_classification(["12345", "Иван", "678", "John"])
+        self.assertEqual(ru, ["Иван"])
+        self.assertEqual(en, ["John"])
 
 
 if __name__ == "__main__":

--- a/tests/test_role_department_logic.py
+++ b/tests/test_role_department_logic.py
@@ -1,5 +1,9 @@
 import unittest
-from services.participant_service import merge_participant_data, detect_changes
+from services.participant_service import (
+    merge_participant_data,
+    detect_changes,
+    update_single_field,
+)
 
 
 class RoleDepartmentLogicTestCase(unittest.TestCase):
@@ -16,6 +20,19 @@ class RoleDepartmentLogicTestCase(unittest.TestCase):
         self.assertEqual(result["Role"], "CANDIDATE")
         self.assertEqual(result.get("Department"), "")
 
+    def test_merge_clears_department_when_role_set_to_team(self):
+        existing = {
+            "FullNameRU": "Test User",
+            "Gender": "M",
+            "Church": "Test",
+            "Role": "",
+            "Department": "Worship",
+        }
+        updates = {"Role": "TEAM"}
+        result = merge_participant_data(existing, updates)
+        self.assertEqual(result["Role"], "TEAM")
+        self.assertEqual(result.get("Department"), "")
+
     def test_detect_changes_shows_department_cleared(self):
         old = {
             "FullNameRU": "Test User",
@@ -27,6 +44,12 @@ class RoleDepartmentLogicTestCase(unittest.TestCase):
         joined = " ".join(changes)
         self.assertIn("Департамент", joined)
         self.assertIn("Worship → —", joined)
+
+    def test_update_single_field_resets_department_on_role_change(self):
+        data = {"Role": "TEAM", "Department": "Worship"}
+        updated, _ = update_single_field(data, "Role", "CANDIDATE")
+        self.assertEqual(updated["Role"], "CANDIDATE")
+        self.assertEqual(updated.get("Department"), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,82 @@
+import unittest
+
+from utils.validators import validate_participant_data
+
+
+class ValidateParticipantDataTestCase(unittest.TestCase):
+    def test_valid_candidate(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "CANDIDATE",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertTrue(valid)
+        self.assertEqual(error, "")
+
+    def test_missing_role_fails(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertFalse(valid)
+        self.assertEqual(error, "Не указана роль")
+
+    def test_invalid_role_fails(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "UNKNOWN",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertFalse(valid)
+        self.assertEqual(error, "Не указана роль")
+
+    def test_missing_gender_fails(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "CANDIDATE",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertFalse(valid)
+        self.assertEqual(error, "Пол должен быть M или F")
+
+    def test_team_requires_department(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "L",
+            "Church": "Благодать",
+            "Role": "TEAM",
+            "Department": "",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertFalse(valid)
+        self.assertEqual(error, "Для роли TEAM необходимо указать департамент")
+
+    def test_missing_size_fails(self):
+        data = {
+            "FullNameRU": "Иван Петров",
+            "Gender": "M",
+            "Size": "",
+            "Church": "Благодать",
+            "Role": "CANDIDATE",
+        }
+        valid, error = validate_participant_data(data)
+        self.assertFalse(valid)
+        self.assertEqual(error, "Недопустимый размер одежды")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -2,36 +2,49 @@ from typing import Dict
 from messages import MESSAGES
 
 VALID_SIZES = [
-    'XS', 'EXTRA SMALL', 'EXTRASMALL',
-    'S', 'SMALL',
-    'M', 'MEDIUM',
-    'L', 'LARGE',
-    'XL', 'EXTRA LARGE', 'EXTRALARGE',
-    'XXL', '2XL', 'EXTRA EXTRA LARGE',
-    '3XL', 'XXXL'
+    "XS",
+    "EXTRA SMALL",
+    "EXTRASMALL",
+    "S",
+    "SMALL",
+    "M",
+    "MEDIUM",
+    "L",
+    "LARGE",
+    "XL",
+    "EXTRA LARGE",
+    "EXTRALARGE",
+    "XXL",
+    "2XL",
+    "EXTRA EXTRA LARGE",
+    "3XL",
+    "XXXL",
 ]
+
 
 def validate_size(size: str) -> bool:
     return size.upper() in [s.upper() for s in VALID_SIZES]
 
 
 def validate_participant_data(data: Dict) -> (bool, str):
-    if not data.get('FullNameRU'):
-        return False, MESSAGES['VALIDATION_ERRORS']['FullNameRU']
+    """Validate participant fields before saving to the database."""
 
-    if data.get('Gender') not in ('M', 'F'):
-        return False, MESSAGES['VALIDATION_ERRORS']['Gender']
+    if not data.get("FullNameRU"):
+        return False, MESSAGES["VALIDATION_ERRORS"]["FullNameRU"]
 
-    if not data.get('Church'):
-        return False, MESSAGES['VALIDATION_ERRORS']['Church']
+    if not data.get("Church"):
+        return False, MESSAGES["VALIDATION_ERRORS"]["Church"]
 
-    if not data.get('Role'):
-        return False, MESSAGES['VALIDATION_ERRORS']['Role']
+    if not data.get("Gender") or data.get("Gender") not in ("M", "F"):
+        return False, MESSAGES["VALIDATION_ERRORS"]["Gender"]
 
-    if data.get('Role') == 'TEAM' and not data.get('Department'):
-        return False, MESSAGES['VALIDATION_ERRORS']['Department']
+    if not data.get("Role") or data.get("Role") not in ("CANDIDATE", "TEAM"):
+        return False, MESSAGES["VALIDATION_ERRORS"]["Role"]
 
-    if data.get('Size') and not validate_size(data['Size']):
-        return False, MESSAGES['VALIDATION_ERRORS']['Size']
+    if data.get("Role") == "TEAM" and not data.get("Department"):
+        return False, MESSAGES["VALIDATION_ERRORS"]["Department"]
 
-    return True, ''
+    if not data.get("Size") or not validate_size(data["Size"]):
+        return False, MESSAGES["VALIDATION_ERRORS"]["Size"]
+
+    return True, ""


### PR DESCRIPTION
## Summary
- enforce that role and gender are non-empty and within allowed values
- ensure size is present and valid
- add tests for participant data validation
- add tests for missing field detection when role is TEAM

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_688cfe20d3dc832483cee9aa6ddc0414