### PR TITLE
feat: add structured user action logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,27 @@ The tests cover the participant parser (`test_parser.py`), database operations (
 - **Database initialization**: `participants.db` is not created automatically when running `main.py`. Execute `python3 database.py` before first use.
 - **Role-based access**: User IDs are hardcoded in `config.py`. Changing roles requires modifying the file and redeploying.
 - **State management**: Conversation states are defined in `states.py`. Ensure handlers respect the current state when extending conversation flows.
+
+## 7. Logging Guidelines
+- Every new command **must** log its usage with `UserActionLogger` at start and end.
+- Updates to business logic should include corresponding log entries.
+- When adding participant fields, ensure their changes are logged through `ParticipantService`.
+- Use `UserActionLogger` exclusively for user actions.
+
+### Examples
+```python
+user_logger.log_user_action(user_id, "command_start", {"command": "/add"})
+user_logger.log_participant_operation(user_id, "update", data, participant_id)
+```
+
+### Mandatory logging
+- Command start and completion
+- CRUD operations on participants
+- Conversation state transitions
+- Errors with full context
+
+### PR Checklist
+- [ ] Commands log start/end via `UserActionLogger`
+- [ ] `ParticipantService` logs all data changes
+- [ ] State handlers use `@log_state_transitions`
+- [ ] Tests cover logging when applicable

--- a/scripts/log_analyzer.py
+++ b/scripts/log_analyzer.py
@@ -1,0 +1,99 @@
+"""Utility script to analyze bot log files.
+
+Provides simple statistics such as user activity by day, command usage,
+average operation times and common errors. Outputs can be rendered to a
+basic HTML report or exported as CSV.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+
+def _read_lines(path: Path) -> Iterable[Dict]:
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def user_activity_by_day(log_file: str) -> Dict[str, int]:
+    counts: Dict[str, int] = defaultdict(int)
+    for entry in _read_lines(Path(log_file)):
+        ts = entry.get("timestamp") or entry.get("time") or ""
+        day = ts.split("T")[0] if "T" in ts else ts[:10]
+        counts[day] += 1
+    return dict(counts)
+
+
+def command_stats(log_file: str) -> Dict[str, int]:
+    counter: Counter[str] = Counter()
+    for entry in _read_lines(Path(log_file)):
+        if entry.get("event") == "user_action":
+            cmd = entry.get("details", {}).get("command")
+            if cmd:
+                counter[cmd] += 1
+    return dict(counter)
+
+
+def operation_times(log_file: str) -> Tuple[float, int]:
+    total, count = 0.0, 0
+    for entry in _read_lines(Path(log_file)):
+        total += float(entry.get("duration", 0))
+        count += 1
+    avg = total / count if count else 0.0
+    return avg, count
+
+
+def frequent_errors(log_file: str) -> Dict[str, int]:
+    counter: Counter[str] = Counter()
+    for entry in _read_lines(Path(log_file)):
+        if entry.get("event") == "error":
+            counter[entry.get("error", "unknown")] += 1
+    return dict(counter)
+
+
+def generate_html_report(stats: Dict[str, Dict], output: str) -> None:
+    html = ["<html><body><h1>Bot Log Report</h1>"]
+    for title, data in stats.items():
+        html.append(f"<h2>{title}</h2><pre>{json.dumps(data, ensure_ascii=False, indent=2)}</pre>")
+    html.append("</body></html>")
+    Path(output).write_text("\n".join(html), encoding="utf-8")
+
+
+def export_csv(data: Dict[str, int], output: str) -> None:
+    with open(output, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["key", "value"])
+        for k, v in data.items():
+            writer.writerow([k, v])
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Analyze bot logs")
+    parser.add_argument("log", help="Path to log file")
+    parser.add_argument("--html", help="Path to output HTML report")
+    parser.add_argument("--csv", help="Path to output CSV file")
+    args = parser.parse_args()
+
+    stats = {
+        "user_activity": user_activity_by_day(args.log),
+        "command_stats": command_stats(args.log),
+    }
+
+    if args.html:
+        generate_html_report(stats, args.html)
+    if args.csv:
+        export_csv(stats["command_stats"], args.csv)

--- a/tests/test_participant_service.py
+++ b/tests/test_participant_service.py
@@ -46,7 +46,7 @@ class ParticipantServiceTestCase(unittest.TestCase):
             "Church": "Тест",
             "Role": "CANDIDATE",
         }
-        participant = self.service.add_participant(data)
+        participant = self.service.add_participant(data, user_id=1)
         self.assertIsNotNone(participant.id)
         self.assertEqual(participant.FullNameRU, "Тестовый Пользователь")
 

--- a/utils/user_logger.py
+++ b/utils/user_logger.py
@@ -1,0 +1,88 @@
+import logging
+import json
+from logging.handlers import RotatingFileHandler
+from typing import Any, Dict, Optional
+
+
+class UserActionLogger:
+    """Structured logger for user-related actions."""
+
+    USER_ACTION_LEVEL = logging.INFO + 5
+    BUSINESS_LOGIC_LEVEL = logging.INFO + 7
+
+    logging.addLevelName(USER_ACTION_LEVEL, "USER_ACTION")
+    logging.addLevelName(BUSINESS_LOGIC_LEVEL, "BUSINESS_LOGIC")
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger("user_action")
+        if not self.logger.handlers:
+            handler = RotatingFileHandler(
+                "user_actions.log", maxBytes=5 * 1024 * 1024, backupCount=5
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+
+    def _log(self, level: int, data: Dict[str, Any]) -> None:
+        self.logger.log(level, json.dumps(data, ensure_ascii=False))
+
+    def log_user_action(
+        self,
+        user_id: int,
+        action: str,
+        details: Dict[str, Any],
+        result: str = "success",
+    ) -> None:
+        data = {
+            "event": "user_action",
+            "user_id": user_id,
+            "action": action,
+            "details": details,
+            "result": result,
+        }
+        self._log(self.USER_ACTION_LEVEL, data)
+
+    def log_participant_operation(
+        self,
+        user_id: int,
+        operation: str,
+        participant_data: Dict[str, Any],
+        participant_id: Optional[int] = None,
+    ) -> None:
+        data = {
+            "event": "participant_operation",
+            "user_id": user_id,
+            "operation": operation,
+            "participant_data": participant_data,
+        }
+        if participant_id is not None:
+            data["participant_id"] = participant_id
+        self._log(self.BUSINESS_LOGIC_LEVEL, data)
+
+    def log_state_transition(
+        self,
+        user_id: int,
+        from_state: str,
+        to_state: str,
+        context: Dict[str, Any],
+    ) -> None:
+        data = {
+            "event": "state_transition",
+            "user_id": user_id,
+            "from_state": from_state,
+            "to_state": to_state,
+            "context": context,
+        }
+        self._log(self.BUSINESS_LOGIC_LEVEL, data)
+
+    def log_error_with_context(
+        self, user_id: int, error: Exception, context: Dict[str, Any], action: str
+    ) -> None:
+        data = {
+            "event": "error",
+            "user_id": user_id,
+            "error": str(error),
+            "context": context,
+            "action": action,
+        }
+        logging.getLogger("errors").error(json.dumps(data, ensure_ascii=False))


### PR DESCRIPTION
## Summary
- add `UserActionLogger` for structured JSON logs of user actions, participant operations, state transitions and errors
- integrate structured logging into command handlers, service layer and conversation state transitions
- add log analysis script and logging guidelines

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_688db1da37cc8324a4199801c96688a0