### PR TITLE
fix: handle Airtable fallback and participant id types

### DIFF
--- a/repositories/airtable_participant_repository.py
+++ b/repositories/airtable_participant_repository.py
@@ -1,11 +1,11 @@
 import logging
-from typing import List, Optional
+from typing import List, Optional, Union
 import time
 
 from pyairtable.api.types import RecordDict
 from pyairtable.formulas import match
 
-from repositories.participant_repository import AbstractParticipantRepository
+from repositories.participant_repository import BaseParticipantRepository
 from models.participant import Participant
 from repositories.airtable_client import AirtableClient
 from utils.exceptions import (
@@ -18,7 +18,7 @@ from utils.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-class AirtableParticipantRepository(AbstractParticipantRepository):
+class AirtableParticipantRepository(BaseParticipantRepository):
     """Airtable implementation of participant repository."""
 
     def __init__(self):
@@ -74,8 +74,9 @@ class AirtableParticipantRepository(AbstractParticipantRepository):
             logger.error(f"Error adding participant to Airtable: {e}")
             raise DatabaseError(f"Airtable error on add: {e}") from e
 
-    def get_by_id(self, participant_id: str) -> Optional[Participant]:
+    def get_by_id(self, participant_id: Union[int, str]) -> Optional[Participant]:
         """Get participant by Airtable record ID."""
+        participant_id = str(participant_id)
         logger.info(f"Getting participant by ID from Airtable: {participant_id}")
 
         try:
@@ -151,14 +152,10 @@ class AirtableParticipantRepository(AbstractParticipantRepository):
             logger.error(f"Error updating participant: {e}")
             raise DatabaseError(f"Airtable error on update: {e}") from e
 
-    def update_fields(self, participant_id: str, **fields) -> bool:
+    def update_fields(self, participant_id: Union[int, str], **fields) -> bool:
         """Update specific fields for a participant."""
-        # Validate fields against Participant dataclass
-        valid_field_names = set(Participant.__annotations__.keys()) - {'id'}
-        invalid_fields = set(fields.keys()) - valid_field_names
-
-        if invalid_fields:
-            raise ValueError(f"Invalid fields for Participant: {invalid_fields}")
+        participant_id = str(participant_id)
+        self._validate_fields(**fields)
 
         logger.info(
             f"Updating fields for participant {participant_id}: {list(fields.keys())}"
@@ -183,8 +180,9 @@ class AirtableParticipantRepository(AbstractParticipantRepository):
             logger.error(f"Error updating participant fields: {e}")
             raise DatabaseError(f"Airtable error on update_fields: {e}") from e
 
-    def delete(self, participant_id: str) -> bool:
+    def delete(self, participant_id: Union[int, str]) -> bool:
         """Delete participant from Airtable."""
+        participant_id = str(participant_id)
         logger.info(f"Deleting participant from Airtable: {participant_id}")
 
         try:
@@ -201,7 +199,7 @@ class AirtableParticipantRepository(AbstractParticipantRepository):
             logger.error(f"Error deleting participant: {e}")
             raise DatabaseError(f"Airtable error on delete: {e}") from e
 
-    def exists(self, participant_id: str) -> bool:
+    def exists(self, participant_id: Union[int, str]) -> bool:
         """Check if participant exists in Airtable."""
         return self.get_by_id(participant_id) is not None
 

--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -474,7 +474,7 @@ class ParticipantService:
         return new_participant
 
     def update_participant(
-        self, participant_id: int, data: Dict, user_id: Optional[int] = None
+        self, participant_id: Union[int, str], data: Dict, user_id: Optional[int] = None
     ) -> bool:
         """
         ✅ ОБНОВЛЕНО: полное обновление через объект Participant.
@@ -521,7 +521,7 @@ class ParticipantService:
         return result
 
     def update_participant_fields(
-        self, participant_id: int, user_id: Optional[int] = None, **fields
+        self, participant_id: Union[int, str], user_id: Optional[int] = None, **fields
     ) -> bool:
         """
         ✅ НОВЫЙ МЕТОД: частичное обновление конкретных полей.
@@ -569,7 +569,7 @@ class ParticipantService:
         )
         return result
 
-    def get_participant(self, participant_id: int) -> Optional[Participant]:
+    def get_participant(self, participant_id: Union[int, str]) -> Optional[Participant]:
         """
         ✅ НОВЫЙ МЕТОД: получение участника по ID.
         """
@@ -584,7 +584,7 @@ class ParticipantService:
         return self.repository.get_all()
 
     def delete_participant(
-        self, participant_id: int, user_id: Optional[int] = None, reason: str = ""
+        self, participant_id: Union[int, str], user_id: Optional[int] = None, reason: str = ""
     ) -> bool:
         """Delete participant and log reason."""
         start = time.time()
@@ -609,7 +609,7 @@ class ParticipantService:
         )
         return result
 
-    def participant_exists(self, participant_id: int) -> bool:
+    def participant_exists(self, participant_id: Union[int, str]) -> bool:
         """
         ✅ НОВЫЙ МЕТОД: проверка существования участника.
         """


### PR DESCRIPTION
## Summary
- define fallback `AirtableApiError` when `pyairtable` isn't installed
- parse participant identifiers as either integers or strings
- introduce `BaseParticipantRepository` with shared field validation

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6891b144c7b4832480b460ddc2f11d8f