### PR TITLE
feat: add participant use case and controller

### DIFF
--- a/domain/models/participant.py
+++ b/domain/models/participant.py
@@ -22,6 +22,23 @@ class Participant:
     country_and_city: str = ""
 
     @classmethod
+    def from_dict(cls, data: dict) -> "Participant":
+        """Создает участника из словаря старого формата."""
+        return cls(
+            id=data.get("id"),
+            full_name_ru=data.get("FullNameRU", ""),
+            gender=Gender.from_string(data.get("Gender", "F")),
+            size=data.get("Size", ""),
+            church=data.get("Church", ""),
+            role=data.get("Role", ""),
+            department=data.get("Department", ""),
+            full_name_en=data.get("FullNameEN", ""),
+            submitted_by=data.get("SubmittedBy", ""),
+            contact_information=data.get("ContactInformation", ""),
+            country_and_city=data.get("CountryAndCity", ""),
+        )
+
+    @classmethod
     def from_legacy(cls, legacy: LegacyParticipant) -> "Participant":
         """Конвертер из старой модели."""
         return cls(

--- a/src/application/controllers/__init__.py
+++ b/src/application/controllers/__init__.py
@@ -1,0 +1,2 @@
+"""Application controllers package."""
+

--- a/src/application/controllers/participant_controller.py
+++ b/src/application/controllers/participant_controller.py
@@ -1,0 +1,51 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from application.use_cases.add_participant import (
+    AddParticipantCommand,
+    AddParticipantUseCase,
+)
+from shared.exceptions import ValidationError
+from utils.user_logger import UserActionLogger
+
+
+class ParticipantController:
+    def __init__(self, add_use_case: AddParticipantUseCase):
+        self.add_use_case = add_use_case
+        self.user_logger = UserActionLogger()
+
+    async def handle_add_participant(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
+        """Обработка добавления участника."""
+
+        user_id = update.effective_user.id
+        self.user_logger.log_user_action(
+            user_id, "command_start", {"command": "/add"}
+        )
+
+        try:
+            command = AddParticipantCommand(
+                user_id=user_id,
+                participant_data=context.user_data.get("parsed_participant", {}),
+            )
+
+            participant = await self.add_use_case.execute(command)
+
+            self.user_logger.log_user_action(
+                user_id, "command_end", {"command": "/add"}
+            )
+            await update.message.reply_text(
+                f"✅ Участник {participant.full_name_ru} добавлен!"
+            )
+
+        except ValidationError as e:
+            self.user_logger.log_user_action(
+                user_id,
+                "command_end",
+                {"command": "/add", "result": "error", "errors": e.errors},
+            )
+            await update.message.reply_text(
+                f"❌ Ошибка валидации: {'; '.join(e.errors)}"
+            )
+

--- a/src/application/use_cases/__init__.py
+++ b/src/application/use_cases/__init__.py
@@ -1,0 +1,2 @@
+"""Application use case package."""
+

--- a/src/application/use_cases/add_participant.py
+++ b/src/application/use_cases/add_participant.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+from domain.models.participant import Participant
+from domain.services.participant_validator import ParticipantValidator
+from domain.interfaces.repositories import ParticipantRepositoryInterface
+from shared.exceptions import ValidationError
+
+
+@dataclass
+class AddParticipantCommand:
+    user_id: int
+    participant_data: dict
+
+
+class AddParticipantUseCase:
+    def __init__(
+        self,
+        repository: ParticipantRepositoryInterface,
+        validator: ParticipantValidator,
+    ):
+        self.repository = repository
+        self.validator = validator
+
+    async def execute(self, command: AddParticipantCommand) -> Participant:
+        """Validate and persist a new participant."""
+
+        validation_result = self.validator.validate(command.participant_data)
+        if not validation_result.is_valid:
+            raise ValidationError(validation_result.errors)
+
+        participant = Participant.from_dict(command.participant_data)
+        return await self.repository.save(participant)
+

--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -10,3 +10,30 @@ class Container(containers.DeclarativeContainer):
         'services.participant_service.ParticipantService',
         repository=providers.Singleton('repositories.participant_repository.SqliteParticipantRepository')
     )
+
+    # Domain Services
+    participant_validator = providers.Factory(
+        'domain.services.participant_validator.ParticipantValidator',
+        legacy_validator=providers.Callable('utils.validators.validate_participant_data'),
+    )
+
+    # Repositories
+    participant_repository = providers.Factory(
+        'infrastructure.repositories.participant_repository_adapter.ParticipantRepositoryAdapter',
+        legacy_repository=providers.Factory(
+            'repositories.participant_repository.SqliteParticipantRepository'
+        ),
+    )
+
+    # Use Cases
+    add_participant_use_case = providers.Factory(
+        'application.use_cases.add_participant.AddParticipantUseCase',
+        repository=participant_repository,
+        validator=participant_validator,
+    )
+
+    # Controllers
+    participant_controller = providers.Factory(
+        'application.controllers.participant_controller.ParticipantController',
+        add_use_case=add_participant_use_case,
+    )


### PR DESCRIPTION
## Summary
- add `AddParticipantUseCase` for validating and persisting participants
- wire controller and use case into DI container
- expose controller for handling participant creation with logging

## Testing
- `PYTHONPATH=src python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68922ab3a6ac8324bc41012d2cbff52e