### PR TITLE
refactor: split handlers into modules

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -6,6 +6,7 @@ class Container(containers.DeclarativeContainer):
     # Start with basic dependencies
     config = providers.Configuration()
     logger = providers.Singleton(logging.getLogger, "bot")
+    user_logger = providers.Singleton("utils.user_logger.UserActionLogger")
 
     # Keep existing components working
     legacy_participant_service = providers.Singleton(
@@ -47,5 +48,46 @@ class Container(containers.DeclarativeContainer):
     # Handlers
     start_handler = providers.Factory(
         "presentation.handlers.command_handlers.StartCommandHandler",
+        container=providers.Self(),
+    )
+    add_handler = providers.Factory(
+        "presentation.handlers.command_handlers.AddCommandHandler",
+        container=providers.Self(),
+    )
+    help_handler = providers.Factory(
+        "presentation.handlers.command_handlers.HelpCommandHandler",
+        container=providers.Self(),
+    )
+    list_handler = providers.Factory(
+        "presentation.handlers.command_handlers.ListCommandHandler",
+        container=providers.Self(),
+    )
+    search_handler = providers.Factory(
+        "presentation.handlers.command_handlers.SearchCommandHandler",
+        container=providers.Self(),
+    )
+    cancel_handler = providers.Factory(
+        "presentation.handlers.command_handlers.CancelCommandHandler",
+        container=providers.Self(),
+    )
+
+    add_callback_handler = providers.Factory(
+        "presentation.handlers.callback_handlers.AddCallbackHandler",
+        container=providers.Self(),
+    )
+    search_callback_handler = providers.Factory(
+        "presentation.handlers.callback_handlers.SearchCallbackHandler",
+        container=providers.Self(),
+    )
+    main_menu_callback_handler = providers.Factory(
+        "presentation.handlers.callback_handlers.MainMenuCallbackHandler",
+        container=providers.Self(),
+    )
+    save_confirmation_callback_handler = providers.Factory(
+        "presentation.handlers.callback_handlers.SaveConfirmationCallbackHandler",
+        container=providers.Self(),
+    )
+    duplicate_callback_handler = providers.Factory(
+        "presentation.handlers.callback_handlers.DuplicateCallbackHandler",
         container=providers.Self(),
     )

--- a/src/presentation/handlers/base_handler.py
+++ b/src/presentation/handlers/base_handler.py
@@ -7,6 +7,14 @@ class BaseHandler(ABC):
     def __init__(self, container):
         self.container = container
         self.logger = container.logger() if hasattr(container, "logger") else None
+        self.user_logger = (
+            container.user_logger() if hasattr(container, "user_logger") else None
+        )
+        self.participant_service = (
+            container.legacy_participant_service()
+            if hasattr(container, "legacy_participant_service")
+            else None
+        )
 
     @abstractmethod
     async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/src/presentation/handlers/callback_handlers.py
+++ b/src/presentation/handlers/callback_handlers.py
@@ -1,0 +1,431 @@
+from dataclasses import asdict
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes, ConversationHandler
+
+from presentation.handlers.base_handler import BaseHandler
+from utils.decorators import require_role
+from main import (
+    _add_message_to_cleanup,
+    _cleanup_messages,
+    _show_main_menu,
+    _send_response_with_menu_button,
+    _show_search_prompt,
+    get_duplicate_keyboard,
+    get_post_action_keyboard,
+    format_participant_full_info,
+    format_participant_block,
+    show_confirmation,
+    cleanup_user_data_safe,
+)
+from states import COLLECTING_DATA, CONFIRMING_DUPLICATE
+from messages import MESSAGES
+
+
+class AddCallbackHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("coordinator")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        query = update.callback_query
+        await query.answer()
+        await query.edit_message_reply_markup(reply_markup=None)
+
+        context.user_data["add_flow_data"] = {
+            "FullNameRU": None,
+            "Gender": None,
+            "Size": None,
+            "Church": None,
+            "Role": None,
+            "Department": None,
+            "FullNameEN": None,
+            "CountryAndCity": None,
+            "SubmittedBy": None,
+            "ContactInformation": None,
+        }
+
+        cancel_markup = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")]]
+        )
+
+        msg1 = await query.message.reply_text(
+            "🚀 **Начинаем добавлять нового участника.**\n\n"
+            "Отправьте данные любым удобным способом:\n"
+            "1️⃣ **Вставьте заполненный шаблон** (пришлю его следующим сообщением).\n"
+            "2️⃣ **Отправьте несколько полей**, разделяя их запятой (`,`) или каждое с новой строки.\n"
+            "3️⃣ **Отправляйте по одному полю** в сообщении (например, `Церковь Грейс`).\n\n"
+            "*Для самой точной обработки используйте запятые или ввод с новой строки.*\n"
+            "Для отмены введите /cancel.",
+            parse_mode="Markdown",
+            reply_markup=cancel_markup,
+        )
+        msg2 = await query.message.reply_text(MESSAGES["ADD_TEMPLATE"])
+        _add_message_to_cleanup(context, msg1.message_id)
+        _add_message_to_cleanup(context, msg2.message_id)
+        _add_message_to_cleanup(context, query.message.message_id)
+        context.user_data["current_state"] = COLLECTING_DATA
+        return COLLECTING_DATA
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class SearchCallbackHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        user_id = update.effective_user.id
+        if self.logger:
+            self.logger.info(f"🔍 handle_search_callback called for user {user_id}")
+            self.logger.debug(f"user_data before search: {list(context.user_data.keys())}")
+
+        if context.user_data:
+            if self.logger:
+                self.logger.warning(
+                    f"Found existing user_data during search start: {list(context.user_data.keys())}"
+                )
+            context.user_data.clear()
+
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "search_callback_triggered", {}
+            )
+
+        return await _show_search_prompt(update, context, is_callback=True)
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class MainMenuCallbackHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        query = update.callback_query
+        await query.answer()
+        data = query.data
+        user_id = update.effective_user.id
+        if self.user_logger:
+            self.user_logger.log_user_action(user_id, "menu_action", {"action": data})
+
+        await query.edit_message_reply_markup(reply_markup=None)
+
+        if data == "main_cancel":
+            from main import cancel_callback
+
+            return await cancel_callback(update, context)
+
+        if data == "main_menu":
+            await _show_main_menu(update, context, is_return=True)
+            return
+
+        if data == "main_list":
+            participants = self.participant_service.get_all_participants()
+            if not participants:
+                empty_keyboard = InlineKeyboardMarkup(
+                    [
+                        [
+                            InlineKeyboardButton(
+                                "➕ Добавить участника", callback_data="main_add"
+                            )
+                        ],
+                        [
+                            InlineKeyboardButton(
+                                "🏠 Главное меню", callback_data="main_menu"
+                            )
+                        ],
+                    ]
+                )
+
+                await query.message.reply_text(
+                    "📋 **Список участников пуст**\n\nДобавьте первого участника:",
+                    parse_mode="Markdown",
+                    reply_markup=empty_keyboard,
+                )
+                return
+
+            message = f"📋 **Список участников ({len(participants)} чел.):**\n\n"
+            for p in participants:
+                role_emoji = "👤" if p.Role == "CANDIDATE" else "👨‍💼"
+                department = (
+                    f" ({p.Department})" if p.Role == "TEAM" and p.Department else ""
+                )
+                message += f"{role_emoji} **{p.FullNameRU}**\n"
+                message += f"   • Роль: {p.Role}{department}\n"
+                message += f"   • ID: {p.id}\n\n"
+
+            await _send_response_with_menu_button(update, message)
+            return
+
+        if data == "main_export":
+            await _send_response_with_menu_button(
+                update,
+                "📤 **Экспорт данных** (заглушка)\n\n",
+                "🔧 Функция в разработке.\n",
+                "Пример: /export worship team - экспорт участников worship команды",
+            )
+            return
+
+        if data == "main_help":
+            help_text = """
+📖 **Справка по командам:**
+
+👥 **Управление участниками:**
+/add - Добавить нового участника
+/edit - Редактировать данные участника
+/delete - Удалить участника
+
+📊 **Просмотр данных:**
+/list - Показать список участников
+/export - Экспорт данных в CSV
+
+❓ **Помощь:**
+/help - Показать эту справку
+/start - Главное меню
+/cancel - Отменить текущую операцию
+
+🔍 **Примеры запросов (скоро):**
+"Сколько team-member в worship?"
+"Кто живет в комнате 203A?"
+            """
+
+            await _send_response_with_menu_button(update, help_text)
+            return
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class SaveConfirmationCallbackHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        from main import smart_cleanup_on_error, log_state_transitions
+
+        self._handle = require_role("coordinator")(
+            smart_cleanup_on_error(log_state_transitions(self._handle))
+        )
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        query = update.callback_query
+        user_id = update.effective_user.id
+
+        if self.logger:
+            self.logger.info(f"Save confirmation requested by user {user_id}")
+            self.logger.debug(f"callback_data: {query.data}")
+            self.logger.debug(
+                f"user_data keys: {list(context.user_data.keys())}")
+
+        await query.answer()
+        await _cleanup_messages(context, update.effective_chat.id)
+
+        participant_data = context.user_data.get("parsed_participant", {})
+        if not participant_data:
+            await query.message.reply_text(
+                "❌ Не удалось найти данные для сохранения. Попробуйте снова."
+            )
+            cleanup_user_data_safe(context, update.effective_user.id)
+            return ConversationHandler.END
+
+        is_update = "participant_id" in context.user_data
+
+        if not is_update:
+            existing = self.participant_service.check_duplicate(
+                participant_data.get("FullNameRU"), user_id=user_id
+            )
+            if existing:
+                context.user_data["existing_participant_id"] = existing.get("id")
+                message = "⚠️ **Найден дубликат!**\n\n"
+                message += format_participant_block(existing)
+                message += "\n\nЧто делаем?"
+                await query.message.reply_text(
+                    message,
+                    parse_mode="Markdown",
+                    reply_markup=get_duplicate_keyboard(),
+                )
+                return CONFIRMING_DUPLICATE
+
+        try:
+            if is_update:
+                participant_id = context.user_data["participant_id"]
+                self.participant_service.update_participant(
+                    participant_id, participant_data, user_id=user_id
+                )
+                if self.user_logger:
+                    self.user_logger.log_participant_operation(
+                        user_id, "update", participant_data, participant_id
+                    )
+                    self.user_logger.log_user_action(
+                        user_id,
+                        "command_end",
+                        {
+                            "command": "/add",
+                            "participant_id": participant_id,
+                            "result": "updated",
+                        },
+                    )
+                updated_participant = self.participant_service.get_participant(
+                    participant_id
+                )
+                if updated_participant:
+                    full_info = format_participant_full_info(
+                        asdict(updated_participant)
+                    )
+                    success_message = f"✅ **Участник обновлен!**\n\n{full_info}"
+                else:
+                    success_message = (
+                        f"✅ **Участник {participant_data['FullNameRU']} (ID: {participant_id})"
+                        " успешно обновлен!**"
+                    )
+            else:
+                new_participant = self.participant_service.add_participant(
+                    participant_data, user_id=user_id
+                )
+                if self.user_logger:
+                    self.user_logger.log_participant_operation(
+                        user_id, "add", participant_data, new_participant.id
+                    )
+                    self.user_logger.log_user_action(
+                        user_id,
+                        "command_end",
+                        {
+                            "command": "/add",
+                            "participant_id": new_participant.id,
+                            "result": "added",
+                        },
+                    )
+                full_info = format_participant_full_info(asdict(new_participant))
+                success_message = f"✅ **Участник добавлен!**\n\n{full_info}"
+        except Exception:
+            raise
+
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "✏️ Редактировать",
+                        callback_data=(
+                            f"edit_participant_{new_participant.id}"
+                            if not is_update
+                            else f"edit_participant_{participant_id}"
+                        ),
+                    ),
+                    InlineKeyboardButton("➕ Добавить еще", callback_data="main_add"),
+                ],
+                [InlineKeyboardButton("🏠 Главное меню", callback_data="main_menu")],
+            ]
+        )
+
+        await query.message.reply_text(
+            success_message,
+            parse_mode="Markdown",
+            reply_markup=keyboard,
+        )
+
+        cleanup_user_data_safe(context, update.effective_user.id)
+        return ConversationHandler.END
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class DuplicateCallbackHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        from main import smart_cleanup_on_error, log_state_transitions
+
+        self._handle = smart_cleanup_on_error(
+            log_state_transitions(self._handle)
+        )
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        query = update.callback_query
+        await query.answer()
+
+        action = query.data
+        participant_data = context.user_data.get("parsed_participant", {})
+        user_id = update.effective_user.id if update.effective_user else 0
+
+        if action == "dup_add_new":
+            try:
+                new_participant = self.participant_service.add_participant(
+                    participant_data, user_id=user_id
+                )
+                if self.user_logger:
+                    self.user_logger.log_participant_operation(
+                        user_id, "add", participant_data, new_participant.id
+                    )
+                    self.user_logger.log_user_action(
+                        user_id,
+                        "command_end",
+                        {
+                            "command": "/add",
+                            "participant_id": new_participant.id,
+                            "result": "added_duplicate",
+                        },
+                    )
+            except Exception as e:
+                raise
+            cleanup_user_data_safe(context, update.effective_user.id)
+
+            await query.message.reply_text(
+                f"✅ **Участник добавлен как новый (возможен дубль)**\n\n"
+                f"🆔 ID: {new_participant.id}\n"
+                f"👤 Имя: {participant_data['FullNameRU']}\n\n"
+                f"⚠️ Обратите внимание на возможное дублирование!",
+                parse_mode="Markdown",
+                reply_markup=get_post_action_keyboard(),
+            )
+
+        elif action == "dup_replace":
+            existing = self.participant_service.check_duplicate(
+                participant_data["FullNameRU"], user_id=user_id
+            )
+            if existing:
+                try:
+                    updated = self.participant_service.update_participant(
+                        existing.id, participant_data, user_id=user_id
+                    )
+                    if self.user_logger:
+                        self.user_logger.log_participant_operation(
+                            user_id, "update", participant_data, existing.id
+                        )
+                        self.user_logger.log_user_action(
+                            user_id,
+                            "command_end",
+                            {
+                                "command": "/add",
+                                "participant_id": existing.id,
+                                "result": "updated_duplicate",
+                            },
+                        )
+                except Exception:
+                    raise
+                cleanup_user_data_safe(context, update.effective_user.id)
+
+                if updated:
+                    await query.message.reply_text(
+                        f"🔄 **Участник обновлен!**\n\n"
+                        f"🆔 ID: {existing.id}\n"
+                        f"👤 Имя: {participant_data['FullNameRU']}\n"
+                        f"👥 Роль: {participant_data['Role']}\n\n"
+                        f"📋 Данные заменены новыми значениями",
+                        parse_mode="Markdown",
+                        reply_markup=get_post_action_keyboard(),
+                    )
+                else:
+                    await query.message.reply_text(
+                        "❌ Ошибка обновления участника."
+                    )
+            else:
+                await query.message.reply_text(
+                    "❌ Существующий участник не найден."
+                )
+
+        return ConversationHandler.END
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -1,12 +1,295 @@
-from telegram import Update
-from telegram.ext import ContextTypes
+from datetime import datetime
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes, ConversationHandler
 
 from presentation.handlers.base_handler import BaseHandler
+from utils.decorators import require_role
+from utils.session_recovery import detect_interrupted_session, handle_session_recovery
+from messages import MESSAGES
+from states import COLLECTING_DATA
+from main import (
+    _cleanup_messages,
+    _show_main_menu,
+    _record_action,
+    _log_session_end,
+    _send_response_with_menu_button,
+    _show_search_prompt,
+)
 
 
 class StartCommandHandler(BaseHandler):
-    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
-        # Пока просто вызываем старую логику
-        from main import start_command
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
 
-        return await start_command(update, context)
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        _log_session_end(context, user_id)
+        context.user_data["session_start"] = datetime.utcnow()
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/start"}
+            )
+        _record_action(context, "/start:start")
+
+        if self.logger:
+            self.logger.info("User %s started /start", user_id)
+        await _cleanup_messages(context, update.effective_chat.id)
+        await _show_main_menu(update, context)
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_end", {"command": "/start"}
+            )
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class AddCommandHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        from main import cleanup_on_error
+
+        self._handle = require_role("coordinator")(
+            cleanup_on_error(self._handle)
+        )
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/add"}
+            )
+        _record_action(context, "/add:start")
+
+        context.user_data["add_flow_data"] = {
+            "FullNameRU": None,
+            "Gender": None,
+            "Size": None,
+            "Church": None,
+            "Role": None,
+            "Department": None,
+            "FullNameEN": None,
+            "CountryAndCity": None,
+            "SubmittedBy": None,
+            "ContactInformation": None,
+        }
+
+        cancel_markup = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("❌ Отмена", callback_data="main_cancel")]]
+        )
+
+        msg1 = await update.message.reply_text(
+            "🚀 **Начинаем добавлять нового участника.**\n\n"
+            "Отправьте данные любым удобным способом:\n"
+            "1️⃣ **Вставьте заполненный шаблон** (пришлю его следующим сообщением).\n"
+            "2️⃣ **Отправьте несколько полей**, разделяя их запятой (`,`) или каждое с новой строки.\n"
+            "3️⃣ **Отправляйте по одному полю** в сообщении (например, `Церковь Грейс`).\n\n"
+            "*Для самой точной обработки используйте запятые или ввод с новой строки.*\n"
+            "Для отмены введите /cancel.",
+            parse_mode="Markdown",
+            reply_markup=cancel_markup,
+        )
+        msg2 = await update.message.reply_text(MESSAGES["ADD_TEMPLATE"])
+        from main import _add_message_to_cleanup
+
+        _add_message_to_cleanup(context, msg1.message_id)
+        _add_message_to_cleanup(context, msg2.message_id)
+        _add_message_to_cleanup(context, update.message.message_id)
+        context.user_data["current_state"] = COLLECTING_DATA
+        if self.user_logger:
+            self.user_logger.log_state_transition(
+                user_id, "START", str(COLLECTING_DATA), {}
+            )
+        return COLLECTING_DATA
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class HelpCommandHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/help"}
+            )
+        _record_action(context, "/help:start")
+        from main import get_user_role
+
+        role = get_user_role(user_id)
+        if self.logger:
+            self.logger.info("User %s requested help", user_id)
+
+        help_text = """
+📖 **Справка по командам:**
+
+👥 **Управление участниками:**
+/add - Добавить нового участника
+/edit - Редактировать данные участника
+/delete - Удалить участника
+
+📊 **Просмотр данных:**
+/list - Показать список участников
+/export - Экспорт данных в CSV
+
+❓ **Помощь:**
+/help - Показать эту справку
+/start - Главное меню
+/cancel - Отменить текущую операцию
+
+🔍 **Примеры запросов (скоро):**
+"Сколько team-member в worship?"
+"Кто живет в комнате 203A?"
+        """
+
+        await _send_response_with_menu_button(update, help_text)
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_end", {"command": "/help"}
+            )
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class ListCommandHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        from main import get_user_role
+
+        role = get_user_role(user_id)
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/list"}
+            )
+        _record_action(context, "/list:start")
+
+        participants = self.participant_service.get_all_participants()
+
+        if not participants:
+            empty_keyboard = InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(
+                            "➕ Добавить участника", callback_data="main_add"
+                        )
+                    ],
+                    [InlineKeyboardButton("🏠 Главное меню", callback_data="main_menu")],
+                ]
+            )
+
+            await update.message.reply_text(
+                "📋 **Список участников пуст**\n\nДобавьте первого участника:",
+                parse_mode="Markdown",
+                reply_markup=empty_keyboard,
+            )
+            if self.user_logger:
+                self.user_logger.log_user_action(
+                    user_id, "command_end", {"command": "/list", "count": 0}
+                )
+            return
+
+        message = f"📋 **Список участников ({len(participants)} чел.):**\n\n"
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_end", {"command": "/list", "count": len(participants)}
+            )
+
+        for p in participants:
+            role_emoji = "👤" if p.Role == "CANDIDATE" else "👨‍💼"
+            department = f" ({p.Department})" if p.Role == "TEAM" and p.Department else ""
+
+            message += f"{role_emoji} **{p.FullNameRU}**\n"
+            message += f"   • Роль: {p.Role}{department}\n"
+            message += f"   • ID: {p.id}\n\n"
+
+        await _send_response_with_menu_button(update, message)
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class SearchCommandHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/search"}
+            )
+        _record_action(context, "/search:start")
+        return await _show_search_prompt(update, context, is_callback=False)
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)
+
+
+class CancelCommandHandler(BaseHandler):
+    def __init__(self, container):
+        super().__init__(container)
+        self._handle = require_role("viewer")(self._handle)
+
+    async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        user_id = update.effective_user.id
+        if detect_interrupted_session(update, context):
+            await handle_session_recovery(update, context)
+            return
+
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_start", {"command": "/cancel"}
+            )
+        _record_action(context, "/cancel:start")
+        _log_session_end(context, user_id)
+        if context.user_data:
+            context.user_data.clear()
+            if self.logger:
+                self.logger.info("User %s cancelled the add flow.", user_id)
+        else:
+            if self.logger:
+                self.logger.info(
+                    "User %s cancelled a non-existent operation.", user_id
+                )
+
+        await _cleanup_messages(context, update.effective_chat.id)
+        await _show_main_menu(update, context, is_return=True)
+        if self.user_logger:
+            self.user_logger.log_user_action(
+                user_id, "command_end", {"command": "/cancel"}
+            )
+        return ConversationHandler.END
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        return await self._handle(update, context)

--- a/src/presentation/handlers/conversation_handlers.py
+++ b/src/presentation/handlers/conversation_handlers.py
@@ -1,0 +1,6 @@
+from presentation.handlers.base_handler import BaseHandler
+
+
+class PlaceholderConversationHandler(BaseHandler):
+    async def handle(self, update, context):
+        raise NotImplementedError

--- a/src/presentation/handlers/middleware_handlers.py
+++ b/src/presentation/handlers/middleware_handlers.py
@@ -1,0 +1,6 @@
+from presentation.handlers.base_handler import BaseHandler
+
+
+class PlaceholderMiddlewareHandler(BaseHandler):
+    async def handle(self, update, context):
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- move command handlers (/start, /add, /help, /list, /search, /cancel) into class-based modules
- extract callback handlers (main menu, search, add, save, duplicate) and wire via DI container
- adjust tests for new handler structure

## Testing
- `PYTHONPATH=src:. python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_689244567a4c8324a0cfc8e92daea6cd