### PR TITLE
feat: integrate middleware and extend UI

### DIFF
--- a/src/presentation/ui/components/validation_ui.py
+++ b/src/presentation/ui/components/validation_ui.py
@@ -1,6 +1,47 @@
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 
 
 async def show_validation_errors(update: Update, errors: dict) -> None:
-    lines = [f"- {field}: {', '.join(errs)}" for field, errs in errors.items()]
-    await update.message.reply_text("\n".join(lines))
+    lines = ["❌ **Ошибки валидации:**\n"]
+    for field, field_errors in errors.items():
+        lines.append(f"• **{field}**: {', '.join(field_errors)}")
+
+    message = '\n'.join(lines)
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🔄 Попробовать снова", callback_data="retry")],
+            [InlineKeyboardButton("❌ Отмена", callback_data="cancel")],
+        ]
+    )
+
+    await update.message.reply_text(
+        message, parse_mode="Markdown", reply_markup=keyboard
+    )
+
+
+async def show_duplicate_warning(update: Update, existing_participant: dict) -> None:
+    message = f"""⚠️ **Участник уже существует!**
+    
+**Найденный участник:**
+- Имя: {existing_participant.get('FullNameRU')}
+- ID: {existing_participant.get('id')}
+- Роль: {existing_participant.get('Role')}
+
+Что делать?"""
+
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("✏️ Изменить данные", callback_data="modify_data")],
+            [
+                InlineKeyboardButton(
+                    "👁️ Просмотреть",
+                    callback_data=f"view_{existing_participant['id']}",
+                )
+            ],
+            [InlineKeyboardButton("❌ Отмена", callback_data="cancel")],
+        ]
+    )
+
+    await update.message.reply_text(
+        message, parse_mode="Markdown", reply_markup=keyboard
+    )

--- a/src/presentation/ui/factory.py
+++ b/src/presentation/ui/factory.py
@@ -1,13 +1,61 @@
-from telegram import InlineKeyboardMarkup
+from typing import List
 
-from .keyboards import ParticipantKeyboardFactory
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 
 class UIFactory:
-    """Simple factory to create UI elements."""
+    """Factory to create common UI elements."""
 
     def create_add_participant_form(self) -> InlineKeyboardMarkup:
-        return ParticipantKeyboardFactory.create_main_menu("coordinator")
+        return InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "📝 Заполнить шаблон", callback_data="template"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        "✍️ Ввести вручную", callback_data="manual"
+                    )
+                ],
+                [InlineKeyboardButton("❌ Отмена", callback_data="cancel")],
+            ]
+        )
 
     def create_success_keyboard(self) -> InlineKeyboardMarkup:
-        return ParticipantKeyboardFactory.create_main_menu("coordinator")
+        return InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "🏠 Главное меню", callback_data="main_menu"
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        "➕ Добавить ещё", callback_data="add_more"
+                    )
+                ],
+            ]
+        )
+
+    def create_search_results_keyboard(self, results: List) -> InlineKeyboardMarkup:
+        buttons: List[List[InlineKeyboardButton]] = []
+        for participant in results[:5]:
+            buttons.append(
+                [
+                    InlineKeyboardButton(
+                        f"{participant.FullNameRU}",
+                        callback_data=f"select_{participant.id}",
+                    )
+                ]
+            )
+        if len(results) > 5:
+            buttons.append(
+                [
+                    InlineKeyboardButton(
+                        "➡️ Ещё результаты", callback_data="more_results"
+                    )
+                ]
+            )
+        return InlineKeyboardMarkup(buttons)


### PR DESCRIPTION
## Summary
- expand `UIFactory` with participant form, success menu, and search results keyboards
- refactor `ListCommandHandler` to use use case and new UI components
- add validation UI helpers and wire auth/logging middleware into application

## Testing
- `PYTHONPATH=src python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6892fae9610883248c38cc6f48ccb0eb