### PR TITLE
fix: apply middleware to callbacks and init ui factory

### DIFF
--- a/main.py
+++ b/main.py
@@ -159,6 +159,21 @@ def create_application():
         )
         application.add_handler(CommandHandler(command, wrapped))
 
+    callback_map = {
+        "add_callback_handler": "^main_add$",
+        "search_callback_handler": "^main_search$",
+        "main_menu_callback_handler": "^main_(list|export|help|menu|cancel)$",
+        "save_confirmation_callback_handler": "^confirm_save$",
+        "duplicate_callback_handler": "^dup_",
+    }
+
+    for provider_name, pattern in callback_map.items():
+        handler_instance = getattr(container, provider_name)()
+        wrapped = compose_middleware(
+            handler_instance, [auth_middleware, logging_middleware]
+        )
+        application.add_handler(CallbackQueryHandler(wrapped, pattern=pattern))
+
     return application, container
 
 

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -197,6 +197,7 @@ class ListCommandHandler(BaseHandler):
     def __init__(self, container):
         super().__init__(container)
         self.list_use_case = container.list_participants_use_case()
+        self.ui_factory = container.ui_factory()
         self._handle = require_role("viewer")(self._handle)
 
     async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary
- initialize UI factory in `ListCommandHandler`
- apply auth and logging middleware to callback handlers in `create_application`

## Testing
- `PYTHONPATH=src python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6892fd39ddfc832495a0781d87f5ffdb