### PR TITLE
fix: call handlers without logging wrapper

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ def compose_middleware(handler, middlewares):
         if result is None:
             return
         update, context = result
-        return await handler.handle_with_logging(update, context)
+        return await handler.handle(update, context)
 
     return wrapped
 

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -183,6 +183,7 @@ class HelpCommandHandler(BaseHandler):
 "Кто живет в комнате 203A?"
         """
 
+        # Respond with help text and return user to main menu
         await _send_response_with_menu_button(update, help_text)
         if self.user_logger:
             self.user_logger.log_user_action(


### PR DESCRIPTION
## Summary
- call base handler directly in middleware
- document help command response

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'shared')*

------
https://chatgpt.com/codex/tasks/task_e_6892fec78b1483248a9d714feb5253ea