### PR TITLE
fix: move container import to module scope

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ import time
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+
+from infrastructure.container import Container
 
 import traceback
 from collections import defaultdict
@@ -133,8 +135,6 @@ def compose_middleware(handler, middlewares):
 
 def create_application():
     """Создание и настройка приложения."""
-    from infrastructure.container import Container
-
     container = Container()
     container.configure_events()
 


### PR DESCRIPTION
## Summary
- move Container import to module scope after updating sys.path handling

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'shared', 'infrastructure.repositories.participant_repository_adapter')*

------
https://chatgpt.com/codex/tasks/task_e_68930532a90083249cb79e7f8cc7488e