### PR TITLE
fix: use models participant import

### DIFF
--- a/src/presentation/ui/formatters/participant_formatter.py
+++ b/src/presentation/ui/formatters/participant_formatter.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 
-from domain.models.participant import Participant
+from models.participant import Participant
 
 
 def format_participant(participant: Participant) -> str:


### PR DESCRIPTION
## Summary
- fix participant formatter to import Participant from models

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'shared'; No module named 'domain.services.participant_validator')*

------
https://chatgpt.com/codex/tasks/task_e_689306d4e184832483abe4e6accc406d