### PR TITLE
refactor: switch container to Airtable repository

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -12,7 +12,7 @@ class Container(containers.DeclarativeContainer):
     legacy_participant_service = providers.Singleton(
         "services.participant_service.ParticipantService",
         repository=providers.Singleton(
-            "repositories.participant_repository.SqliteParticipantRepository"
+            "repositories.airtable_participant_repository.AirtableParticipantRepository"
         ),
     )
 
@@ -29,10 +29,7 @@ class Container(containers.DeclarativeContainer):
 
     # Repositories
     participant_repository = providers.Factory(
-        "infrastructure.repositories.participant_repository_adapter.ParticipantRepositoryAdapter",
-        legacy_repository=providers.Factory(
-            "repositories.participant_repository.SqliteParticipantRepository"
-        ),
+        "repositories.airtable_participant_repository.AirtableParticipantRepository"
     )
 
     # duplicate_checker = providers.Factory(


### PR DESCRIPTION
## Summary
- use `AirtableParticipantRepository` instead of SQLite in dependency injection container

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'domain.models.participant')*


------
https://chatgpt.com/codex/tasks/task_e_689311c0cf8c8324a61b5f0bb4328096