### PR TITLE
refactor: update Participant imports

### DIFF
--- a/infrastructure/repositories/participant_repository_adapter.py
+++ b/infrastructure/repositories/participant_repository_adapter.py
@@ -1,5 +1,5 @@
 from domain.interfaces.repositories import ParticipantRepositoryInterface
-from domain.models.participant import Participant
+from models.participant import Participant
 from repositories.participant_repository import SqliteParticipantRepository
 
 

--- a/src/application/use_cases/add_participant.py
+++ b/src/application/use_cases/add_participant.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 
-from domain.models.participant import Participant
+from models.participant import Participant
 from domain.services.participant_validator import ParticipantValidator
 from domain.services.duplicate_checker import DuplicateCheckerService
 from domain.specifications.participant_specifications import (

--- a/src/application/use_cases/get_participant.py
+++ b/src/application/use_cases/get_participant.py
@@ -1,7 +1,7 @@
 import logging
 
 from services.participant_service import ParticipantService
-from domain.models.participant import Participant
+from models.participant import Participant
 from .decorators import log_use_case
 
 

--- a/src/application/use_cases/list_participants.py
+++ b/src/application/use_cases/list_participants.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from services.participant_service import ParticipantService
-from domain.models.participant import Participant
+from models.participant import Participant
 from .decorators import log_use_case
 
 

--- a/src/application/use_cases/update_participant.py
+++ b/src/application/use_cases/update_participant.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 from domain.services.participant_validator import ParticipantValidator
 from domain.services.duplicate_checker import DuplicateCheckerService
-from domain.models.participant import Participant
+from models.participant import Participant
 from domain.specifications.participant_specifications import (
     TeamRoleRequiresDepartmentSpecification,
 )

--- a/src/domain/services/duplicate_checker.py
+++ b/src/domain/services/duplicate_checker.py
@@ -1,5 +1,5 @@
 from domain.interfaces.repositories import ParticipantRepositoryInterface
-from domain.models.participant import Participant
+from models.participant import Participant
 from typing import Optional
 
 

--- a/src/domain/specifications/participant_specifications.py
+++ b/src/domain/specifications/participant_specifications.py
@@ -1,4 +1,4 @@
-from domain.models.participant import Participant
+from models.participant import Participant
 
 
 class TeamRoleRequiresDepartmentSpecification:

--- a/tests/integration/test_event_flow.py
+++ b/tests/integration/test_event_flow.py
@@ -47,7 +47,7 @@ class TestEventFlow:
         self.validator.validate.return_value = Mock(is_valid=True)
         self.duplicate_checker.check_duplicate.return_value = None
 
-        from domain.models.participant import Participant
+        from models.participant import Participant
 
         participant = Participant.from_dict({"FullNameRU": "Test", "Gender": "M"})
         participant.id = 1

--- a/tests/unit/event_handlers/test_participant_event_listener.py
+++ b/tests/unit/event_handlers/test_participant_event_listener.py
@@ -14,7 +14,7 @@ from domain.events.participant_events import (
     ParticipantAddedEvent,
     ParticipantUpdatedEvent,
 )
-from domain.models.participant import Participant
+from models.participant import Participant
 
 
 class TestParticipantEventListener:

--- a/tests/unit/use_cases/test_add_participant.py
+++ b/tests/unit/use_cases/test_add_participant.py
@@ -10,7 +10,7 @@ from application.use_cases.add_participant import (
     AddParticipantCommand,
     AddParticipantUseCase,
 )
-from domain.models.participant import Participant
+from models.participant import Participant
 
 
 class TestAddParticipantUseCase:

--- a/tests/unit/use_cases/test_update_participant.py
+++ b/tests/unit/use_cases/test_update_participant.py
@@ -10,7 +10,7 @@ from application.use_cases.update_participant import (
     UpdateParticipantCommand,
     UpdateParticipantUseCase,
 )
-from domain.models.participant import Participant
+from models.participant import Participant
 from shared.exceptions import DuplicateParticipantError
 
 


### PR DESCRIPTION
## Summary
- switch Participant imports from `domain.models` to `models`
- adjust tests and services to use new `Participant` module

## Testing
- `PYTHONPATH=.:src python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'domain.services.participant_validator')*

------
https://chatgpt.com/codex/tasks/task_e_6893154a85ac8324b72cacd47da31aa0