### PR TITLE
chore: restore domain package and clean src init

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,1 @@
-import sys
-from pathlib import Path
-
-# Ensure modules under src can be imported without the `src.` prefix
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+# This file intentionally left blank to mark the package.


### PR DESCRIPTION
## Summary
- restore domain package under src/domain
- clean src package __init__ to remove path hack

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'utils', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68933382b8308324b00935c6df4c0f0d