### PR TITLE
refactor: inject services into handlers

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -122,6 +122,7 @@ class Container(containers.DeclarativeContainer):
     help_handler = providers.Factory(
         "presentation.handlers.command_handlers.HelpCommandHandler",
         container=providers.Self(),
+        message_service=message_service,
     )
     list_handler = providers.Factory(
         "presentation.handlers.command_handlers.ListCommandHandler",
@@ -142,18 +143,23 @@ class Container(containers.DeclarativeContainer):
     add_callback_handler = providers.Factory(
         "presentation.handlers.callback_handlers.AddCallbackHandler",
         container=providers.Self(),
+        message_service=message_service,
     )
     search_callback_handler = providers.Factory(
         "presentation.handlers.callback_handlers.SearchCallbackHandler",
         container=providers.Self(),
+        ui_service=ui_service,
     )
     main_menu_callback_handler = providers.Factory(
         "presentation.handlers.callback_handlers.MainMenuCallbackHandler",
         container=providers.Self(),
+        ui_service=ui_service,
+        message_service=message_service,
     )
     save_confirmation_callback_handler = providers.Factory(
         "presentation.handlers.callback_handlers.SaveConfirmationCallbackHandler",
         container=providers.Self(),
+        ui_service=ui_service,
     )
     duplicate_callback_handler = providers.Factory(
         "presentation.handlers.callback_handlers.DuplicateCallbackHandler",

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -136,8 +136,9 @@ class UpdateParticipantHandler(BaseHandler):
 
 
 class HelpCommandHandler(BaseHandler):
-    def __init__(self, container):
+    def __init__(self, container, message_service):
         super().__init__(container)
+        self.message_service = message_service
         self._handle = require_role("viewer")(self._handle)
 
     async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -184,7 +185,7 @@ class HelpCommandHandler(BaseHandler):
         """
 
         # Respond with help text and return user to main menu
-        await _send_response_with_menu_button(update, help_text)
+        await self.message_service.send_response_with_menu_button(update, help_text)
         if self.user_logger:
             self.user_logger.log_user_action(
                 user_id, "command_end", {"command": "/help"}

--- a/tests/test_search_flow.py
+++ b/tests/test_search_flow.py
@@ -17,10 +17,11 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
             context.user_data["current_state"] = SEARCHING_PARTICIPANTS
             return SEARCHING_PARTICIPANTS
 
-        with patch(
-            "src.presentation.handlers.callback_handlers._show_search_prompt",
-            side_effect=mock_show_search_prompt,
-        ), patch("main.user_logger"), patch(
+        ui_service = SimpleNamespace(
+            show_search_prompt=AsyncMock(side_effect=mock_show_search_prompt)
+        )
+
+        with patch("main.user_logger"), patch(
             "main._cleanup_messages", new=AsyncMock()
         ), patch(
             "main._show_main_menu", new=AsyncMock()
@@ -34,7 +35,7 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
             container = SimpleNamespace(
                 logger=lambda: MagicMock(), user_logger=lambda: MagicMock()
             )
-            handler = SearchCallbackHandler(container)
+            handler = SearchCallbackHandler(container, ui_service)
             state = await handler.handle(update, context)
             self.assertEqual(state, SEARCHING_PARTICIPANTS)
             self.assertIn("current_state", context.user_data)
@@ -55,7 +56,7 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
             update2 = SimpleNamespace(
                 callback_query=MagicMock(), effective_user=SimpleNamespace(id=1)
             )
-            handler2 = SearchCallbackHandler(container)
+            handler2 = SearchCallbackHandler(container, ui_service)
             state2 = await handler2.handle(update2, context)
             self.assertEqual(state2, SEARCHING_PARTICIPANTS)
             self.assertIn("current_state", context.user_data)


### PR DESCRIPTION
## Summary
- inject `MessageService` into HelpCommandHandler
- switch callback handlers to use UI and Message services
- wire up services through the container

## Testing
- `python -m pytest` *(fails: 9 errors during collection)*
- `python -m unittest` *(fails: circular import and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689352ca3d5c8324b55819053050297e