### PR TITLE
chore: remove obsolete bot helper utilities

### DIFF
--- a/src/presentation/handlers/callback_handlers.py
+++ b/src/presentation/handlers/callback_handlers.py
@@ -9,7 +9,6 @@ from main import (
     get_post_action_keyboard,
     format_participant_full_info,
     format_participant_block,
-    show_confirmation,
     cleanup_user_data_safe,
 )
 from states import COLLECTING_DATA, CONFIRMING_DUPLICATE
@@ -61,9 +60,7 @@ class AddCallbackHandler(BaseHandler):
         msg2 = await query.message.reply_text(MESSAGES["ADD_TEMPLATE"])
         self.message_service.add_message_to_cleanup(context, msg1.message_id)
         self.message_service.add_message_to_cleanup(context, msg2.message_id)
-        self.message_service.add_message_to_cleanup(
-            context, query.message.message_id
-        )
+        self.message_service.add_message_to_cleanup(context, query.message.message_id)
         context.user_data["current_state"] = COLLECTING_DATA
         return COLLECTING_DATA
 
@@ -100,7 +97,9 @@ class SearchCallbackHandler(BaseHandler):
         if self.user_logger:
             self.user_logger.log_user_action(user_id, "search_callback_triggered", {})
 
-        return await self.ui_service.show_search_prompt(update, context, is_callback=True)
+        return await self.ui_service.show_search_prompt(
+            update, context, is_callback=True
+        )
 
     async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         return await self._handle(update, context)

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -9,7 +9,7 @@ from utils.decorators import require_role
 from utils.session_recovery import detect_interrupted_session, handle_session_recovery
 from messages import MESSAGES
 from states import COLLECTING_DATA
-from utils.bot_helpers import _record_action, _log_session_end, cleanup_on_error
+from utils.bot_helpers import _record_action, _log_session_end
 from presentation.ui.formatters.participant_formatter import format_participant
 from config import COORDINATOR_IDS, VIEWER_IDS
 
@@ -52,7 +52,9 @@ class AddCommandHandler(BaseHandler):
     def __init__(self, container, message_service):
         super().__init__(container)
         self.message_service = message_service
-        self._handle = require_role("coordinator")(cleanup_on_error(self._handle))
+        from main import smart_cleanup_on_error
+
+        self._handle = require_role("coordinator")(smart_cleanup_on_error(self._handle))
 
     async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id
@@ -289,7 +291,9 @@ class SearchCommandHandler(BaseHandler):
                     {"command": "/search", "count": len(results)},
                 )
             return ConversationHandler.END
-        return await self.ui_service.show_search_prompt(update, context, is_callback=False)
+        return await self.ui_service.show_search_prompt(
+            update, context, is_callback=False
+        )
 
     async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         return await self._handle(update, context)

--- a/src/utils/bot_helpers.py
+++ b/src/utils/bot_helpers.py
@@ -1,14 +1,10 @@
-import logging
 import time
 from datetime import datetime
-from functools import wraps
 
-from telegram import Update
-from telegram.ext import ContextTypes, ConversationHandler
+from telegram.ext import ContextTypes
 
 from .user_logger import UserActionLogger
 
-logger = logging.getLogger(__name__)
 user_logger = UserActionLogger()
 
 
@@ -26,54 +22,3 @@ def _log_session_end(context: ContextTypes.DEFAULT_TYPE, user_id: int) -> None:
     if start:
         duration = (datetime.utcnow() - start).total_seconds()
         user_logger.log_user_action(user_id, "session_end", {"duration": duration})
-
-
-def cleanup_user_data_safe(
-    context: ContextTypes.DEFAULT_TYPE, user_id: int | None = None
-) -> None:
-    """Safely clear user_data with logging."""
-    if context.user_data:
-        keys_to_clear = list(context.user_data.keys())
-        context.user_data.clear()
-        logger.info(
-            "Cleared user_data for user %s: %s", user_id or "unknown", keys_to_clear
-        )
-
-
-def cleanup_on_error(func):
-    """Decorator to automatically cleanup user_data on errors."""
-
-    @wraps(func)
-    async def wrapper(
-        update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs
-    ):
-        try:
-            return await func(update, context, *args, **kwargs)
-        except Exception as e:  # pragma: no cover - log path
-            user_id = update.effective_user.id if update.effective_user else "unknown"
-            logger.error(
-                "Error in %s for user %s: %s", func.__name__, user_id, e, exc_info=True
-            )
-            cleanup_user_data_safe(context, update.effective_user.id)
-            try:
-                if update.message:
-                    await update.message.reply_text(
-                        "❌ **Произошла ошибка при обработке данных.**\n\n"
-                        "🔄 Попробуйте снова с команды /add\n"
-                        "📞 Если проблема повторяется, обратитесь к администратору.",
-                        parse_mode="Markdown",
-                    )
-                elif update.callback_query:
-                    await update.callback_query.answer()
-                    await update.callback_query.message.reply_text(
-                        "❌ **Произошла ошибка при обработке данных.**\n\n"
-                        "🔄 Попробуйте снова с команды /add",
-                        parse_mode="Markdown",
-                    )
-            except Exception as send_error:  # pragma: no cover
-                logger.error(
-                    "Failed to send error message to user %s: %s", user_id, send_error
-                )
-            return ConversationHandler.END
-
-    return wrapper


### PR DESCRIPTION
## Summary
- drop leftover helper imports from command and callback handlers
- trim `bot_helpers` to only recording actions and session duration

## Testing
- `python -m black src/presentation/handlers/command_handlers.py src/presentation/handlers/callback_handlers.py src/utils/bot_helpers.py`
- `python3 -m unittest discover tests` *(fails: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68935567943483248f83561107d50666