### PR TITLE
fix: use relative imports for presentation modules

### DIFF
--- a/src/services/participant_service.py
+++ b/src/services/participant_service.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-from presentation.ui.legacy_keyboards import (
+from ..presentation.ui.legacy_keyboards import (
     get_department_selection_keyboard,
     get_department_selection_keyboard_required,
     get_edit_keyboard,
@@ -19,7 +19,7 @@ from presentation.ui.legacy_keyboards import (
     get_size_selection_keyboard,
     get_size_selection_keyboard_required,
 )
-from presentation.ui.formatters import MessageFormatter
+from ..presentation.ui.formatters import MessageFormatter
 from ..repositories.participant_repository import AbstractParticipantRepository
 from ..models.participant import Participant
 from ..database import find_participant_by_name


### PR DESCRIPTION
## Summary
- use relative imports for `legacy_keyboards` and `MessageFormatter`

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'messages', 'config', 'constants', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689367ff096483248543df918a818421