### PR TITLE
fix: use relative imports for internal modules

### DIFF
--- a/src/presentation/ui/legacy_keyboards.py
+++ b/src/presentation/ui/legacy_keyboards.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-from constants import DEPARTMENT_DISPLAY
+from ...constants import DEPARTMENT_DISPLAY
 
 
 def get_gender_selection_keyboard() -> InlineKeyboardMarkup:

--- a/src/services/participant_service.py
+++ b/src/services/participant_service.py
@@ -23,14 +23,14 @@ from ..presentation.ui.formatters import MessageFormatter
 from ..repositories.participant_repository import AbstractParticipantRepository
 from ..models.participant import Participant
 from ..database import find_participant_by_name
-from utils.validators import validate_participant_data
+from ..utils.validators import validate_participant_data
 from ..shared.exceptions import (
     DuplicateParticipantError,
     ParticipantNotFoundError,
     ValidationError,
 )
-from parsers.participant_parser import normalize_field_value
-from constants import (
+from ..parsers.participant_parser import normalize_field_value
+from ..constants import (
     GENDER_DISPLAY,
     ROLE_DISPLAY,
     SIZE_DISPLAY,

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from messages import MESSAGES
+from ..messages import MESSAGES
 
 VALID_SIZES = [
     "XS",


### PR DESCRIPTION
## Summary
- use relative import for `messages` in validators
- use relative import for `constants` in legacy keyboards
- fix remaining absolute imports in `ParticipantService`

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'config'; FAILED (errors=15))*

------
https://chatgpt.com/codex/tasks/task_e_68936999f95c8324a83f899d8ca60d2f