### PR TITLE
refactor: decouple presentation from services

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,10 +27,15 @@ from src.utils.decorators import require_role
 from src.utils.cache import load_reference_data
 from src.utils.timeouts import set_edit_timeout, clear_expired_edit
 from src.utils.user_logger import UserActionLogger
-from src.utils.session_recovery import detect_interrupted_session, handle_session_recovery
+from src.utils.session_recovery import (
+    detect_interrupted_session,
+    handle_session_recovery,
+)
 from src.database import init_database
 from src.repositories.participant_repository import SqliteParticipantRepository
-from src.repositories.airtable_participant_repository import AirtableParticipantRepository
+from src.repositories.airtable_participant_repository import (
+    AirtableParticipantRepository,
+)
 from src.infrastructure.container import Container
 
 try:
@@ -57,11 +62,12 @@ from src.parsers.participant_parser import (
 )
 from src.services.participant_service import (
     merge_participant_data,
-    format_participant_block,
     detect_changes,
     update_single_field,
-    get_edit_keyboard,
     FIELD_LABELS,
+)
+from src.presentation.ui.keyboard_factory import (
+    get_edit_keyboard,
     get_gender_selection_keyboard,
     get_gender_selection_keyboard_simple,
     get_role_selection_keyboard,
@@ -72,6 +78,7 @@ from src.services.participant_service import (
     get_role_selection_keyboard_required,
     get_department_selection_keyboard_required,
 )
+from src.presentation.ui.formatters import MessageFormatter
 from src.utils.validators import validate_participant_data
 from src.shared.exceptions import (
     BotException,
@@ -807,7 +814,7 @@ async def show_confirmation(
     logger.info(f"Showing confirmation for user {user_id}")
     logger.debug(f"user_data keys: {list(context.user_data.keys())}")
     confirmation_text = "🔍 Вот что удалось распознать. Всё правильно?\n\n"
-    confirmation_text += format_participant_block(participant_data)
+    confirmation_text += MessageFormatter.format_participant_info(participant_data)
     confirmation_text += '\n\n✅ Нажмите "Сохранить", чтобы завершить, или выберите поле для исправления.'
     keyboard = get_edit_keyboard(participant_data)
     logger.debug(f"Generated keyboard with {len(keyboard.inline_keyboard)} rows")
@@ -1032,7 +1039,7 @@ async def show_interactive_missing_field(
 def format_status_message(participant_data: Dict) -> str:
     """Creates a status message with filled data and missing fields."""
     message = "📝 **Процесс добавления:**\n\n"
-    message += format_participant_block(participant_data)
+    message += MessageFormatter.format_participant_info(participant_data)
     message += "\n\n"
 
     missing = get_missing_fields(participant_data)
@@ -1884,7 +1891,7 @@ async def process_participant_confirmation(
             "✏️ **Изменено:**\n"
             + "\n".join(changes)
             + "\n\n👤 **Итоговые данные:**\n"
-            + format_participant_block(participant_data)
+            + MessageFormatter.format_participant_info(participant_data)
             + "\n\n✅ **Что делать дальше?**\n"
             "- Напишите **ДА** или **НЕТ**\n"
             "- Или пришлите новые исправления"

--- a/src/presentation/handlers/callback_handlers.py
+++ b/src/presentation/handlers/callback_handlers.py
@@ -8,9 +8,9 @@ from main import (
     get_duplicate_keyboard,
     get_post_action_keyboard,
     format_participant_full_info,
-    format_participant_block,
     cleanup_user_data_safe,
 )
+from src.presentation.ui.formatters import MessageFormatter
 from states import COLLECTING_DATA, CONFIRMING_DUPLICATE
 from messages import MESSAGES
 from application.use_cases.add_participant import AddParticipantCommand
@@ -257,7 +257,7 @@ class SaveConfirmationCallbackHandler(BaseHandler):
             if existing and existing.FullNameRU.lower() == name.lower():
                 context.user_data["existing_participant_id"] = existing.id
                 message = "⚠️ **Найден дубликат!**\n\n"
-                message += format_participant_block(asdict(existing))
+                message += MessageFormatter.format_participant_info(asdict(existing))
                 message += "\n\nЧто делаем?"
                 await query.message.reply_text(
                     message,

--- a/src/presentation/ui/formatters/participant_formatter.py
+++ b/src/presentation/ui/formatters/participant_formatter.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict
 
-from models.participant import Participant
+from src.models.participant import Participant
 
 
 def format_participant(participant: Participant) -> str:

--- a/src/presentation/ui/keyboard_factory.py
+++ b/src/presentation/ui/keyboard_factory.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-from ...constants import DEPARTMENT_DISPLAY
+from src.constants import DEPARTMENT_DISPLAY
 
 
 def get_gender_selection_keyboard() -> InlineKeyboardMarkup:

--- a/src/services/participant_service.py
+++ b/src/services/participant_service.py
@@ -1,25 +1,9 @@
 import json
 import logging
-import logging
 import time
 from dataclasses import asdict, dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-
-from ..presentation.ui.legacy_keyboards import (
-    get_department_selection_keyboard,
-    get_department_selection_keyboard_required,
-    get_edit_keyboard,
-    get_gender_selection_keyboard,
-    get_gender_selection_keyboard_required,
-    get_gender_selection_keyboard_simple,
-    get_role_selection_keyboard,
-    get_role_selection_keyboard_required,
-    get_size_selection_keyboard,
-    get_size_selection_keyboard_required,
-)
-from ..presentation.ui.formatters import MessageFormatter
 from ..repositories.participant_repository import AbstractParticipantRepository
 from ..models.participant import Participant
 from ..database import find_participant_by_name
@@ -109,11 +93,6 @@ def merge_participant_data(
         merged["Department"] = ""
 
     return merged
-
-
-def format_participant_block(data: Dict) -> str:
-    """Proxy to new message formatter for backward compatibility."""
-    return MessageFormatter.format_participant_info(data)
 
 
 def detect_changes(old: Dict, new: Dict) -> List[str]:

--- a/tests/test_edit_keyboard.py
+++ b/tests/test_edit_keyboard.py
@@ -1,5 +1,5 @@
 import unittest
-from src.services.participant_service import (
+from src.presentation.ui.keyboard_factory import (
     get_edit_keyboard,
     get_gender_selection_keyboard_simple,
     get_role_selection_keyboard,
@@ -78,8 +78,11 @@ class EditKeyboardTestCase(unittest.TestCase):
         self.assertNotIn("manual_input_Department", datas_dept)
 
         kb_gender = get_gender_selection_keyboard_required()
-        datas_gender = [b.callback_data for row in kb_gender.inline_keyboard for b in row]
+        datas_gender = [
+            b.callback_data for row in kb_gender.inline_keyboard for b in row
+        ]
         self.assertNotIn("manual_input_Gender", datas_gender)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix participant formatter import path
- move keyboard builders to presentation layer and clean participant service
- update handlers and tests to use new keyboard factory

## Testing
- `PYTHONPATH=src python -m unittest discover tests` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_68937cd989b083248dabc22049308cfb