### PR TITLE
fix: use relative imports in participant parser

### DIFF
--- a/src/parsers/participant_parser.py
+++ b/src/parsers/participant_parser.py
@@ -3,15 +3,15 @@ from dataclasses import dataclass
 import re
 import logging
 
-from utils.field_normalizer import (
+from ..utils.field_normalizer import (
     field_normalizer,
     normalize_gender,
     normalize_role,
     normalize_size,
     normalize_department,
 )
-from utils.cache import cache
-from utils.recognizers import (
+from ..utils.cache import cache
+from ..utils.recognizers import (
     recognize_role,
     recognize_gender,
     recognize_size,
@@ -19,7 +19,7 @@ from utils.recognizers import (
     recognize_church,
     recognize_city,
 )
-from constants import (
+from ..constants import (
     gender_from_display,
     role_from_display,
     size_from_display,

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -17,8 +17,8 @@ cache = SimpleCache()
 
 def load_reference_data():
     """Load cities and departments into cache."""
-    from constants import ISRAEL_CITIES
-    from utils.field_normalizer import field_normalizer
+    from ..constants import ISRAEL_CITIES
+    from .field_normalizer import field_normalizer
 
     # Теперь департаменты берем из нормализатора
     cache.set("departments", field_normalizer.DEPARTMENT_MAPPINGS)

--- a/src/utils/recognizers.py
+++ b/src/utils/recognizers.py
@@ -1,6 +1,6 @@
 from typing import Optional
-from utils.cache import cache
-from utils.field_normalizer import (
+from .cache import cache
+from .field_normalizer import (
     normalize_gender,
     normalize_role,
     normalize_size,
@@ -39,7 +39,7 @@ def recognize_department(token: str) -> Optional[str]:
         return None
 
     try:  # pragma: no cover - optional dependency
-        from parsers.participant_parser import FuzzyMatcher
+        from ..parsers.participant_parser import FuzzyMatcher
 
         matcher = FuzzyMatcher(
             similarity_threshold=0.8
@@ -58,7 +58,7 @@ def recognize_church(token: str) -> Optional[str]:
     churches = get_reference_data("churches")
 
     try:  # pragma: no cover - optional dependency
-        from parsers.participant_parser import FuzzyMatcher
+        from ..parsers.participant_parser import FuzzyMatcher
 
         matcher = FuzzyMatcher()
         fuzzy_result = matcher.find_best_church_match(token, churches)


### PR DESCRIPTION
## Summary
- fix participant parser imports to use package-relative paths
- adjust utility modules to use relative imports

## Testing
- `python3 -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'domain')*


------
https://chatgpt.com/codex/tasks/task_e_6893834a458083249a337df4b9d98618