### PR TITLE
fix: remove configure_events invocation

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,6 @@ def create_application(container=None):
     """Создание и настройка приложения."""
     if container is None:
         container = Container()
-        container.configure_events()
 
     auth_middleware = AuthMiddleware(container)
     logging_middleware = LoggingMiddleware()


### PR DESCRIPTION
## Summary
- avoid AttributeError by removing `container.configure_events()` call in `create_application`

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_68938c5c15c88324be578879f8f1754a