### PR TITLE
refactor: inject use cases into command handlers

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -119,6 +119,7 @@ class Container(containers.DeclarativeContainer):
     update_handler = providers.Factory(
         "src.presentation.handlers.command_handlers.UpdateParticipantHandler",
         container=providers.Self(),
+        update_use_case=update_participant_use_case,
     )
     help_handler = providers.Factory(
         "src.presentation.handlers.command_handlers.HelpCommandHandler",
@@ -134,6 +135,7 @@ class Container(containers.DeclarativeContainer):
     search_handler = providers.Factory(
         "src.presentation.handlers.command_handlers.SearchCommandHandler",
         container=providers.Self(),
+        search_use_case=search_participants_use_case,
         ui_service=ui_service,
         message_service=message_service,
     )

--- a/src/presentation/handlers/command_handlers.py
+++ b/src/presentation/handlers/command_handlers.py
@@ -116,9 +116,11 @@ class AddCommandHandler(BaseHandler):
 
 
 class UpdateParticipantHandler(BaseHandler):
-    def __init__(self, container):
+    def __init__(self, container, update_use_case):
         super().__init__(container)
-        self.update_use_case = container.update_participant_use_case()
+        if update_use_case is None:
+            raise ValueError("update_use_case cannot be None")
+        self.update_use_case = update_use_case
         self._handle = require_role("coordinator")(self._handle)
 
     async def _handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -258,9 +260,11 @@ class ListCommandHandler(BaseHandler):
 
 
 class SearchCommandHandler(BaseHandler):
-    def __init__(self, container, ui_service, message_service):
+    def __init__(self, container, ui_service, message_service, search_use_case):
         super().__init__(container)
-        self.search_use_case = container.search_participants_use_case()
+        if search_use_case is None:
+            raise ValueError("search_use_case cannot be None")
+        self.search_use_case = search_use_case
         self.ui_service = ui_service
         self.message_service = message_service
         self._handle = require_role("viewer")(self._handle)


### PR DESCRIPTION
## Summary
- refactor UpdateParticipantHandler to accept an injected update_use_case
- refactor SearchCommandHandler to accept an injected search_use_case
- wire new dependencies in DI container

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_68939473d9308324a0f445512d6b1b0f