### PR TITLE
refactor: inject dependencies into callback handlers

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -153,6 +153,7 @@ class Container(containers.DeclarativeContainer):
     search_callback_handler = providers.Factory(
         "src.presentation.handlers.callback_handlers.SearchCallbackHandler",
         container=providers.Self(),
+        search_use_case=search_participants_use_case,
         ui_service=ui_service,
     )
     main_menu_callback_handler = providers.Factory(
@@ -165,6 +166,10 @@ class Container(containers.DeclarativeContainer):
         "src.presentation.handlers.callback_handlers.SaveConfirmationCallbackHandler",
         container=providers.Self(),
         ui_service=ui_service,
+        add_use_case=add_participant_use_case,
+        update_use_case=update_participant_use_case,
+        search_use_case=search_participants_use_case,
+        get_use_case=get_participant_use_case,
     )
     duplicate_callback_handler = providers.Factory(
         "src.presentation.handlers.callback_handlers.DuplicateCallbackHandler",

--- a/src/presentation/handlers/callback_handlers.py
+++ b/src/presentation/handlers/callback_handlers.py
@@ -63,13 +63,11 @@ class AddCallbackHandler(BaseHandler):
 
 
 class SearchCallbackHandler(BaseHandler):
-    def __init__(self, container, ui_service):
+    def __init__(self, container, ui_service, search_use_case):
         super().__init__(container)
-        self.search_use_case = (
-            container.search_participants_use_case()
-            if hasattr(container, "search_participants_use_case")
-            else None
-        )
+        if search_use_case is None:
+            raise ValueError("search_use_case cannot be None")
+        self.search_use_case = search_use_case
         self.ui_service = ui_service
         self._handle = require_role("viewer")(self._handle)
 
@@ -203,15 +201,32 @@ class MainMenuCallbackHandler(BaseHandler):
 
 
 class SaveConfirmationCallbackHandler(BaseHandler):
-    def __init__(self, container, ui_service):
+    def __init__(
+        self,
+        container,
+        ui_service,
+        add_use_case,
+        update_use_case,
+        search_use_case,
+        get_use_case,
+    ):
         super().__init__(container)
         self.ui_service = ui_service
         from main import smart_cleanup_on_error, log_state_transitions
 
-        self.add_use_case = container.add_participant_use_case()
-        self.update_use_case = container.update_participant_use_case()
-        self.search_use_case = container.search_participants_use_case()
-        self.get_use_case = container.get_participant_use_case()
+        if add_use_case is None:
+            raise ValueError("add_use_case cannot be None")
+        if update_use_case is None:
+            raise ValueError("update_use_case cannot be None")
+        if search_use_case is None:
+            raise ValueError("search_use_case cannot be None")
+        if get_use_case is None:
+            raise ValueError("get_use_case cannot be None")
+
+        self.add_use_case = add_use_case
+        self.update_use_case = update_use_case
+        self.search_use_case = search_use_case
+        self.get_use_case = get_use_case
 
         self._handle = require_role("coordinator")(
             smart_cleanup_on_error(log_state_transitions(self._handle))

--- a/tests/test_search_flow.py
+++ b/tests/test_search_flow.py
@@ -23,9 +23,7 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
 
         with patch("main.user_logger"), patch(
             "main._cleanup_messages", new=AsyncMock()
-        ), patch(
-            "main._show_main_menu", new=AsyncMock()
-        ), patch(
+        ), patch("main._show_main_menu", new=AsyncMock()), patch(
             "main._log_session_end"
         ), patch(
             "src.utils.decorators.VIEWER_IDS", [1]
@@ -35,7 +33,8 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
             container = SimpleNamespace(
                 logger=lambda: MagicMock(), user_logger=lambda: MagicMock()
             )
-            handler = SearchCallbackHandler(container, ui_service)
+            search_use_case = AsyncMock()
+            handler = SearchCallbackHandler(container, ui_service, search_use_case)
             state = await handler.handle(update, context)
             self.assertEqual(state, SEARCHING_PARTICIPANTS)
             self.assertIn("current_state", context.user_data)
@@ -56,7 +55,8 @@ class SearchFlowTestCase(unittest.IsolatedAsyncioTestCase):
             update2 = SimpleNamespace(
                 callback_query=MagicMock(), effective_user=SimpleNamespace(id=1)
             )
-            handler2 = SearchCallbackHandler(container, ui_service)
+            search_use_case2 = AsyncMock()
+            handler2 = SearchCallbackHandler(container, ui_service, search_use_case2)
             state2 = await handler2.handle(update2, context)
             self.assertEqual(state2, SEARCHING_PARTICIPANTS)
             self.assertIn("current_state", context.user_data)


### PR DESCRIPTION
## Summary
- inject SearchUseCase into SearchCallbackHandler and validate
- inject participant use cases into SaveConfirmationCallbackHandler
- wire handlers with explicit dependencies in DI container

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6893965066b8832485bcd6354b9588ed