### PR TITLE
fix: add database type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ pip install -r requirements.txt
 2.  Создайте файл `.env` в корне проекта:
     ```
     BOT_TOKEN=ваш_токен_здесь
+    # Тип базы данных: sqlite (по умолчанию) или airtable
+    DATABASE_TYPE=sqlite
+    # Для Airtable также задайте токен и ID базы
+    # AIRTABLE_TOKEN=ваш_airtable_token
+    # AIRTABLE_BASE_ID=ваш_airtable_base_id
     ```
 3.  В `config.py` добавьте ваш Telegram ID в `COORDINATOR_IDS`:
     ```python

--- a/src/config.py
+++ b/src/config.py
@@ -5,15 +5,26 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Токен бота (получите у @BotFather)
-BOT_TOKEN = os.getenv('BOT_TOKEN', 'YOUR_BOT_TOKEN_HERE')
+BOT_TOKEN = os.getenv("BOT_TOKEN", "YOUR_BOT_TOKEN_HERE")
 
 # Настройки бота
-BOT_USERNAME = 'tresdias_israelbot'
+BOT_USERNAME = "tresdias_israelbot"
+
+# Конфигурация базы данных
+DATABASE_TYPE = os.getenv("DATABASE_TYPE", "sqlite").lower()
+AIRTABLE_TOKEN = os.getenv("AIRTABLE_TOKEN")
+AIRTABLE_BASE_ID = os.getenv("AIRTABLE_BASE_ID")
 
 # Роли пользователей
-COORDINATOR_IDS = [311380449, 5212991086, 649919193, 8086614107, 476732940]  # ID пользователей-координаторов
-VIEWER_IDS = []       # ID пользователей-наблюдателей
+COORDINATOR_IDS = [
+    311380449,
+    5212991086,
+    649919193,
+    8086614107,
+    476732940,
+]  # ID пользователей-координаторов
+VIEWER_IDS = []  # ID пользователей-наблюдателей
 
 # Проверка конфигурации
-if BOT_TOKEN == 'YOUR_BOT_TOKEN_HERE':
+if BOT_TOKEN == "YOUR_BOT_TOKEN_HERE":
     print("⚠️  ВНИМАНИЕ: Установите BOT_TOKEN в файле .env")


### PR DESCRIPTION
## Summary
- add DATABASE_TYPE and Airtable credentials in config
- document database environment variables in README

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6893a8f7ecf483248d6c9552d5b92fd0