### PR TITLE
fix: configure events in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -2361,6 +2361,7 @@ def main():
     # Initialize dependency container and application
     global participant_service
     application, container = create_application()
+    container.configure_events()
     container.config.from_dict(
         {
             "database": {"path": "participants.db"},


### PR DESCRIPTION
## Summary
- initialize event configuration after creating the dependency container

## Testing
- `python3 -m unittest discover tests`

### PR Checklist
- [ ] Commands log start/end via `UserActionLogger`
- [ ] `ParticipantService` logs all data changes
- [ ] State handlers use `@log_state_transitions`
- [ ] Tests cover logging when applicable
- [ ] Check logs are written to `logs/` directory

------
https://chatgpt.com/codex/tasks/task_e_6893ab91b1f483249d000be1e7a48e70