### PR TITLE
fix: inject validator directly

### DIFF
--- a/src/infrastructure/container.py
+++ b/src/infrastructure/container.py
@@ -1,6 +1,8 @@
 import logging
 from dependency_injector import containers, providers
 
+from src.utils.validators import validate_participant_data
+
 
 class Container(containers.DeclarativeContainer):
     # Start with basic dependencies
@@ -19,9 +21,7 @@ class Container(containers.DeclarativeContainer):
     # ✅ Domain Services
     participant_validator = providers.Factory(
         "src.domain.services.participant_validator.ParticipantValidator",
-        legacy_validator=providers.Callable(
-            "src.utils.validators.validate_participant_data"
-        ),
+        legacy_validator=providers.Object(validate_participant_data),
     )
 
     # Repositories

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -49,3 +49,10 @@ def test_add_participant_use_case_provider():
     assert isinstance(
         use_case.duplicate_checker.repository, AirtableParticipantRepository
     )
+
+
+def test_container_wiring():
+    from src.infrastructure.container import Container
+
+    container = Container()
+    container.check_dependencies()


### PR DESCRIPTION
## Summary
- directly inject `validate_participant_data` into participant validator factory
- add container wiring smoke test

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_6893af7bc0d483249c273f6639d6a330