### PR TITLE
fix: disable per-message handling for conversation handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -2419,6 +2419,7 @@ def main():
             ),
         ],
         per_chat=True,
+        per_message=False,
     )
 
     add_conv = ConversationHandler(
@@ -2483,6 +2484,7 @@ def main():
             CallbackQueryHandler(cancel_callback, pattern="^main_cancel$"),
         ],
         per_chat=True,
+        per_message=False,
     )
     # ConversationHandler должен быть зарегистрирован первым
     application.add_handler(search_conv)


### PR DESCRIPTION
## Summary
- silence PTB per-message warnings for search and add conversations

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_68944d1e04788324812b9e812540f5f0