### PR TITLE
fix: enable per-message handling for conversations

### DIFF
--- a/main.py
+++ b/main.py
@@ -2419,7 +2419,7 @@ def main():
             ),
         ],
         per_chat=True,
-        per_message=False,
+        per_message=True,  # ✅ ИЗМЕНЕНО: было False
     )
 
     add_conv = ConversationHandler(
@@ -2484,7 +2484,7 @@ def main():
             CallbackQueryHandler(cancel_callback, pattern="^main_cancel$"),
         ],
         per_chat=True,
-        per_message=False,
+        per_message=True,  # ✅ ИЗМЕНЕНО: было False
     )
     # ConversationHandler должен быть зарегистрирован первым
     application.add_handler(search_conv)


### PR DESCRIPTION
## Summary
- ensure search conversation handles each message separately
- enable per-message processing in add conversation

## Testing
- `python3 -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_68944fb504a8832489f7708e669cda87