### PR TITLE
fix: use standard configuration for mixed handlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -2419,7 +2419,8 @@ def main():
             ),
         ],
         per_chat=True,
-        per_message=True,  # ✅ ИЗМЕНЕНО: было False
+        per_user=True,   # ✅ ДОБАВЛЕНО
+        per_message=False,  # ✅ ВЕРНУЛИ False
     )
 
     add_conv = ConversationHandler(
@@ -2484,7 +2485,8 @@ def main():
             CallbackQueryHandler(cancel_callback, pattern="^main_cancel$"),
         ],
         per_chat=True,
-        per_message=True,  # ✅ ИЗМЕНЕНО: было False
+        per_user=True,   # ✅ ДОБАВЛЕНО
+        per_message=False,  # ✅ ВЕРНУЛИ False
     )
     # ConversationHandler должен быть зарегистрирован первым
     application.add_handler(search_conv)


### PR DESCRIPTION
## Summary
- configure search conversation handler to standard mixed handler settings
- configure add conversation handler to standard mixed handler settings

## Testing
- `python3 -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_689450db14e88324922365244eda153b