### PR TITLE
TDB-24: Fix edit from search flow — buttons not working

### DIFF
--- a/docs/tests-structure.md
+++ b/docs/tests-structure.md
@@ -1,6 +1,6 @@
 # Test Structure Documentation
 
-**Version**: 2.1  
+**Version**: 2.2  
 **Last Updated**: August 15, 2025
 
 ## Overview
@@ -51,6 +51,7 @@ tests/
 ├── Async Tests (Bot interactions)
 │   ├── test_recover.py            # Error recovery flows
 │   ├── test_search_flow.py        # Search conversation flows (+cache invalidation tests v1.8; new-search flow tests v1.9)
+│   ├── test_search_edit_flow.py   # Edit from search flow: global ^edit_ handler, cancel, and guard (v2.2)
 │   ├── test_delete_logging.py     # Delete logging validation (v1.8)
 │   ├── test_enum_selection_context.py # UI interactions
 │   ├── test_field_edit_cancel.py  # Cancel operations

--- a/main.py
+++ b/main.py
@@ -2765,6 +2765,15 @@ async def edit_field_callback(
     query = update.callback_query
     await query.answer()
 
+    # UX guard: if there is no participant data in context, show a friendly hint
+    if not context.user_data.get("parsed_participant"):
+        await _send_response_with_menu_button(
+            update,
+            "ℹ️ Данные для редактирования не найдены.\n\n"
+            "Выберите участника через поиск (🔍) или начните добавление с /add.",
+        )
+        return CONFIRMING_DATA
+
     _add_message_to_cleanup(context, query.message.message_id)
 
     field_to_edit = query.data.split("_")[1]
@@ -3423,6 +3432,11 @@ def main():
     # ConversationHandler должен быть зарегистрирован первым
     application.add_handler(search_conv)
     application.add_handler(add_conv)
+
+    # Global handler to support edit_* buttons when entering edit from search flow
+    application.add_handler(
+        CallbackQueryHandler(edit_field_callback, pattern="^edit_")
+    )
 
     # Регистрируем обработчики команд
     application.add_handler(CommandHandler("start", start_command))

--- a/tests/test_search_edit_flow.py
+++ b/tests/test_search_edit_flow.py
@@ -1,0 +1,148 @@
+import re
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestSearchEditFlow(unittest.IsolatedAsyncioTestCase):
+    async def test_edit_field_after_search_action_edit(self):
+        # Structural assertion: global application-level handler for ^edit_ must exist
+        # so that edit_* callbacks work when entering edit from search flow.
+        with open("main.py", "r", encoding="utf-8") as f:
+            src = f.read()
+
+        pattern = re.compile(
+            r"application\.add_handler\(\s*CallbackQueryHandler\(\s*edit_field_callback\s*,\s*pattern=\"\^edit_\"\s*\)\s*\)",
+            re.MULTILINE,
+        )
+        self.assertRegex(
+            src,
+            pattern,
+            msg="Global handler for ^edit_ must be registered so edit buttons work after search",
+        )
+
+        # Functional smoke: action_edit should prepare context and next edit_* should keep CONFIRMING_DATA
+        from main import handle_action_selection, edit_field_callback, CONFIRMING_DATA
+        from models.participant import Participant
+
+        user_id = 1
+        # Prepare context with a selected participant as done by search -> selection
+        participant = Participant(
+            FullNameRU="Иван Петров",
+            Gender="M",
+            Size="L",
+            Church="Тест",
+            Role="CANDIDATE",
+        )
+        participant.id = 123
+
+        context = SimpleNamespace(user_data={"selected_participant": participant}, chat_data={})
+
+        action_query = MagicMock()
+        action_query.answer = AsyncMock()
+        action_query.message = MagicMock()
+        action_query.message.reply_text = AsyncMock()
+        action_update = SimpleNamespace(callback_query=action_query, effective_user=SimpleNamespace(id=user_id))
+        action_query.data = "action_edit"
+
+        with patch("main.user_logger"), \
+             patch("main.COORDINATOR_IDS", [user_id]), \
+             patch("utils.decorators.COORDINATOR_IDS", [user_id]), \
+             patch("main.show_confirmation", new=AsyncMock()):
+            state = await handle_action_selection(action_update, context)
+
+        self.assertEqual(state, CONFIRMING_DATA)
+        self.assertEqual(context.user_data.get("participant_id"), 123)
+        self.assertIn("parsed_participant", context.user_data)
+
+        # Now simulate clicking an edit_* button
+        edit_query = MagicMock()
+        edit_query.answer = AsyncMock()
+        edit_query.message = MagicMock()
+        edit_query.message.reply_text = AsyncMock()
+        edit_update = SimpleNamespace(callback_query=edit_query, effective_user=SimpleNamespace(id=user_id))
+        edit_query.data = "edit_Role"
+
+        with patch("main._add_message_to_cleanup", lambda *args, **kwargs: None), \
+             patch("main.safe_create_timeout_job", return_value=None):
+            next_state = await edit_field_callback(edit_update, context)
+
+        self.assertEqual(next_state, CONFIRMING_DATA)
+        self.assertEqual(context.user_data.get("field_to_edit"), "Role")
+
+    async def test_cancel_edit_after_search_entry(self):
+        from main import handle_action_selection, handle_field_edit_cancel, CONFIRMING_DATA
+        from models.participant import Participant
+
+        user_id = 2
+        participant = Participant(
+            FullNameRU="Мария Иванова",
+            Gender="F",
+            Size="M",
+            Church="Тест",
+            Role="CANDIDATE",
+        )
+        participant.id = 321
+
+        context = SimpleNamespace(user_data={"selected_participant": participant}, chat_data={})
+
+        action_query = MagicMock()
+        action_query.answer = AsyncMock()
+        action_query.message = MagicMock()
+        action_query.message.reply_text = AsyncMock()
+        action_update = SimpleNamespace(callback_query=action_query, effective_user=SimpleNamespace(id=user_id))
+        action_query.data = "action_edit"
+
+        with patch("main.user_logger"), \
+             patch("main.COORDINATOR_IDS", [user_id]), \
+             patch("utils.decorators.COORDINATOR_IDS", [user_id]), \
+             patch("main.show_confirmation", new=AsyncMock()):
+            state = await handle_action_selection(action_update, context)
+
+        self.assertEqual(state, CONFIRMING_DATA)
+
+        # Prepare edit state
+        context.user_data["field_to_edit"] = "FullNameRU"
+        context.user_data["clear_edit_job"] = SimpleNamespace(schedule_removal=lambda: None)
+
+        cancel_query = MagicMock()
+        cancel_query.answer = AsyncMock()
+        cancel_query.edit_message_text = AsyncMock()
+        cancel_query.message = MagicMock()
+        cancel_query.message.reply_text = AsyncMock()
+        cancel_update = SimpleNamespace(callback_query=cancel_query, effective_user=SimpleNamespace(id=user_id))
+
+        with patch("main.show_confirmation", new=AsyncMock()) as mock_show, \
+             patch("main.get_edit_keyboard", return_value="kb"):
+            next_state = await handle_field_edit_cancel(cancel_update, context)
+
+        self.assertEqual(next_state, CONFIRMING_DATA)
+        self.assertNotIn("field_to_edit", context.user_data)
+        self.assertNotIn("clear_edit_job", context.user_data)
+        mock_show.assert_awaited_once()
+        cancel_query.edit_message_text.assert_awaited_once()
+
+    async def test_edit_field_without_context_shows_help(self):
+        # Guard: when parsed_participant is missing, edit_* should show a hint and keep state
+        from main import edit_field_callback, CONFIRMING_DATA
+
+        user_id = 3
+        context = SimpleNamespace(user_data={}, chat_data={})
+
+        edit_query = MagicMock()
+        edit_query.answer = AsyncMock()
+        edit_query.message = MagicMock()
+        edit_query.message.reply_text = AsyncMock()
+        edit_update = SimpleNamespace(callback_query=edit_query, effective_user=SimpleNamespace(id=user_id))
+        edit_query.data = "edit_Role"
+
+        # _send_response_with_menu_button uses reply_text; no need to patch
+        state = await edit_field_callback(edit_update, context)
+
+        self.assertEqual(state, CONFIRMING_DATA)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+
+


### PR DESCRIPTION
### Changelog → Changes → Tests
| Area/Module | Change (what & why) | Tests (file::case) |
|----|---|-----|
| main.py | Register global ^edit_ handler to enable edit after search; add UX guard in edit_field_callback | tests/test_search_edit_flow.py::test_edit_field_after_search_action_edit, ::test_cancel_edit_after_search_entry, ::test_edit_field_without_context_shows_help |
| tests | New file test_search_edit_flow.py | same |
| docs | Update docs/tests-structure.md (v2.2) | n/a |

Task doc: tasks/task-2025-08-15-fix-edit-from-search-flow-buttons-not-working/Fix edit from search flow — buttons not working.md
Linear: TDB-24

All tests: 163 passed, 18 warnings.